### PR TITLE
docs(quickstart): should create namespace before apply yaml files

### DIFF
--- a/content/en/docs/setup/quickstart.md
+++ b/content/en/docs/setup/quickstart.md
@@ -52,6 +52,7 @@ helm install kmesh ./deploy/helm -n kmesh-system --create-namespace
 - Alternatively install from Yaml
   
 ```console
+kubectl create namespace kmesh-system
 kubectl apply -f ./deploy/yaml/
 ```
 


### PR DESCRIPTION
In quickstart, if we directly apply yaml files, it will raise namespace-not-found errors. It'd be better if we add create namespace command.

![image](https://github.com/kmesh-net/website/assets/58595459/82048781-a0b4-4204-b0e9-07fa0ad35fcc)
