### PR TITLE
add waypoint replacement note

### DIFF
--- a/content/en/docs/userguide/install_waypoint.md
+++ b/content/en/docs/userguide/install_waypoint.md
@@ -124,6 +124,8 @@ waypoint default/default-ns-waypoint applied
 namespace/default labeled
 ```
 
+***NOTE: Also need to replace the waypoint image, refer to the relevant content of `Install waypoint in service granularity`***
+
 Then any requests from any pods using the Kmesh, to any service running in `default` namespace, will be routed through that waypoint for L7 processing and policy enforcement.
 
 #### Install waypoint in pod granularity:
@@ -135,6 +137,8 @@ waypoint default/reviews-v2-pod-waypoint applied
 [root@ ~]# kubectl label pod -l version=v2,app=reviews istio.io/use-waypoint=reviews-v2-pod-waypoint
 pod/reviews-v2-5b667bcbf8-spnnh labeled
 ```
+
+***NOTE: Also need to replace the waypoint image, refer to the relevant content of `Install waypoint in service granularity`***
 
 Now any requests from pods in the Kmesh to the `reviews-v2` pod IP will be routed through `reviews-v2-pod-waypoint` waypoint for L7 processing and policy enforcement.
 

--- a/content/en/docs/userguide/install_waypoint.md
+++ b/content/en/docs/userguide/install_waypoint.md
@@ -124,7 +124,11 @@ waypoint default/default-ns-waypoint applied
 namespace/default labeled
 ```
 
-***NOTE: Also need to replace the waypoint image, refer to the relevant content of `Install waypoint in service granularity`***
+***NOTE: Also need to replace the original image of waypoint with the Kmesh customized image.***
+
+```bash
+[root@ ~]# kubectl annotate gateway default-ns-waypoint sidecar.istio.io/proxyImage=ghcr.io/kmesh-net/waypoint:latest
+```
 
 Then any requests from any pods using the Kmesh, to any service running in `default` namespace, will be routed through that waypoint for L7 processing and policy enforcement.
 
@@ -138,7 +142,11 @@ waypoint default/reviews-v2-pod-waypoint applied
 pod/reviews-v2-5b667bcbf8-spnnh labeled
 ```
 
-***NOTE: Also need to replace the waypoint image, refer to the relevant content of `Install waypoint in service granularity`***
+***NOTE: Also need to replace the original image of waypoint with the Kmesh customized image.***
+
+```bash
+[root@ ~]# kubectl annotate gateway reviews-v2-pod-waypoint sidecar.istio.io/proxyImage=ghcr.io/kmesh-net/waypoint:latest
+```
 
 Now any requests from pods in the Kmesh to the `reviews-v2` pod IP will be routed through `reviews-v2-pod-waypoint` waypoint for L7 processing and policy enforcement.
 


### PR DESCRIPTION
Some unfamiliar users may think that contents of `Install waypoint in service granularity`, `Install waypoint in namespace granularity` and `Install waypoint in pod granularity` are self-contained and will not the entire doc from beginning to end.

Thus failing to replace the waypoint image with Kmesh custom image, causing waypoint to not run properly.

Therefor add necessary note.