### PR TITLE
 Improve website icons and styling

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -25,30 +25,30 @@
 
 # Right Menu
 [[main_right]]
-  name = "<i class=\"fab fa-github-alt\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
-  post = ""
+  name = "<i class=\"fab fa-github\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
+  post = "" # No post needed
   url = "https://github.com/kmesh-net/kmesh"
   weight = 10
 
 [[main_right]]
-  name = "<i class=\"fab fa-twitter\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+  name = "<i class=\"fab fa-twitter\" style=\"color: #1DA1F2; font-size: 1rem; line-height: 1.25\"></i>"
   post = ""
   url = "https://twitter.com/Kmesh_net"
   weight = 20
 
-#[[main_right]]
-#  name = "<i class=\"fab fa-slack\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
-#  post = ""
-#  url = "https://app.slack.com/client/T08PSQ7BQ/C052JRURD8V?selected_team_id=T08PSQ7BQ"
-#  weight = 30
+[[main_right]]
+  name = "<i class=\"fab fa-slack\" style=\"background: linear-gradient(to right, #36C5F0 49.9%, #2EB67D 50.1%) top, linear-gradient(to right, #E01E5A 49.9%, #ECB22E 50.1%) bottom; background-size: 100% 50%; background-repeat: no-repeat; -webkit-background-clip: text; -webkit-text-fill-color: transparent; font-size: 1rem; line-height: 1.25\"></i>"
+  post = ""
+  url = "https://app.slack.com/client/T08PSQ7BQ/C06BU2GB8NL"
+  weight = 30
 
 [[main_right]]
-  name = "<i class=\"fab fa-weixin\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+  name = "<i class=\"fab fa-weixin\" style=\"color: #1AAD19; font-size: 1rem; line-height: 1.25\"></i>"
   post = ""
   url = "https://blog.51cto.com/u_15127420/4992806"
   weight = 40
 
-# Documentation
+# Documentation Links
 [[docs]]
   name = "Welcome"
   weight = 5
@@ -67,7 +67,7 @@
 [[docs]]
   name = "User Guide"
   weight = 16
-  identifier = "user guide"
+  identifier = "user_guide"
 
 [[docs]]
   name = "Performance"
@@ -77,7 +77,7 @@
 [[docs]]
   name = "Developer Guide"
   weight = 25
-  identifier = "developer guide"
+  identifier = "developer_guide"
 
 [[docs]]
   name = "Community"

--- a/themes/academic/layouts/partials/navbar.html
+++ b/themes/academic/layouts/partials/navbar.html
@@ -167,7 +167,7 @@
       {{ if .IsTranslated }}
       <li class="nav-item dropdown i18n-dropdown">
         <a href="#" class="nav-link {{ if $show_current_language }}dropdown-toggle{{end}}" data-toggle="dropdown" aria-haspopup="true">
-          <i class="fas fa-globe mr-1" aria-hidden="true"></i>
+          <i class="fas fa-language mr-1" aria-hidden="true" style="color: #007bff;"></i>
           {{- if $show_current_language -}}
             <span class="d-none d-lg-inline">{{ index site.Data.i18n.languages .Lang }}</span>
           {{- end -}}


### PR DESCRIPTION
### What this PR does / why we need it:
Updates website navigation icons and styling to improve visual consistency and user experience:

1. Social Media Icons:
   - Updated Slack icon with official brand colors.
   - Fixed GitHub icon class for better rendering
   - Updated Twitter color to official brand color (#1DA1F2)
   - Updated 51cto.com color to  green color (#1AAD19)

2. Language Selector:
   - Replaced globe icon with language icon for better representation
   - Added blue color (#007bff) to match website theme

3.  Fixed Slack community link

Please let me know if you'd like to see any other improvements or have specific preferences for the icon styling. I'm happy to make additional adjustments to better align with the project's visual guidelines.
