### PR TITLE
restore original sidebar styling

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -25,30 +25,30 @@
 
 # Right Menu
 [[main_right]]
-  name = "<i class=\"fab fa-github-alt\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
-  post = ""
+  name = "<i class=\"fab fa-github\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
+  post = "" # No post needed
   url = "https://github.com/kmesh-net/kmesh"
   weight = 10
 
 [[main_right]]
-  name = "<i class=\"fab fa-twitter\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+  name = "<i class=\"fab fa-twitter\" style=\"color: #1DA1F2; font-size: 1rem; line-height: 1.25\"></i>"
   post = ""
   url = "https://twitter.com/Kmesh_net"
   weight = 20
 
-#[[main_right]]
-#  name = "<i class=\"fab fa-slack\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
-#  post = ""
-#  url = "https://app.slack.com/client/T08PSQ7BQ/C052JRURD8V?selected_team_id=T08PSQ7BQ"
-#  weight = 30
+[[main_right]]
+  name = "<i class=\"fab fa-slack\" style=\"background: linear-gradient(to right, #36C5F0 49.9%, #2EB67D 50.1%) top, linear-gradient(to right, #E01E5A 49.9%, #ECB22E 50.1%) bottom; background-size: 100% 50%; background-repeat: no-repeat; -webkit-background-clip: text; -webkit-text-fill-color: transparent; font-size: 1rem; line-height: 1.25\"></i>"
+  post = ""
+  url = "https://app.slack.com/client/T08PSQ7BQ/C06BU2GB8NL"
+  weight = 30
 
 [[main_right]]
-  name = "<i class=\"fab fa-weixin\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+  name = "<i class=\"fab fa-weixin\" style=\"color: #1AAD19; font-size: 1rem; line-height: 1.25\"></i>"
   post = ""
   url = "https://blog.51cto.com/u_15127420/4992806"
   weight = 40
 
-# Documentation
+# Documentation Links
 [[docs]]
   name = "Welcome"
   weight = 5

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -30,6 +30,14 @@
   url = "https://github.com/kmesh-net/kmesh"
   weight = 10
 
+# Right Menu
+[[main_right]]
+  name = "<i class=\"fab fa-youtube\" style=\"color: #FF0000; font-size: 1rem; line-height: 1.25\"></i>"
+  post = ""
+  url = "https://www.youtube.com/@Kmesh-traffic"
+  weight = 10
+
+
 [[main_right]]
   name = "<i class=\"fab fa-twitter\" style=\"color: #1DA1F2; font-size: 1rem; line-height: 1.25\"></i>"
   post = ""


### PR DESCRIPTION
This PR fixes the sidebar styling that was unintentionally modified by PR #109 
(Improve website icons and styling).

Changes:
- Restore original sidebar appearance

Before:


![Screenshot from 2025-01-23 19-58-53](https://github.com/user-attachments/assets/7dc34cfc-ab0e-4989-a566-0d9950868d4b)

After:

![Screenshot from 2025-01-23 19-59-07](https://github.com/user-attachments/assets/f57a5ae9-5ff8-4511-a12c-a4d74b6d9f51)
