### PR TITLE
Fix: Restore Sidebar Styling Modified by PR #109

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -26,7 +26,7 @@
 # Right Menu
 [[main_right]]
   name = "<i class=\"fab fa-github\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
-  post = "" # No post needed
+  post = "" #
   url = "https://github.com/kmesh-net/kmesh"
   weight = 10
 
@@ -48,7 +48,7 @@
   url = "https://blog.51cto.com/u_15127420/4992806"
   weight = 40
 
-# Documentation Links
+# Documentation
 [[docs]]
   name = "Welcome"
   weight = 5
@@ -67,7 +67,7 @@
 [[docs]]
   name = "User Guide"
   weight = 16
-  identifier = "user_guide"
+  identifier = "user guide"
 
 [[docs]]
   name = "Performance"
@@ -77,7 +77,7 @@
 [[docs]]
   name = "Developer Guide"
   weight = 25
-  identifier = "developer_guide"
+  identifier = "developer guide"
 
 [[docs]]
   name = "Community"


### PR DESCRIPTION
This commit restores the original styling of the sidebar that was unintentionally altered by PR #109 ('Improve website icons and styling').

Changes:
- Reverted modifications to the sidebar's appearance.
- Ensured consistency with the previous design.


<table>
  <tr>
    <td align="center"><strong>Before</strong></td>
    <td align="center"><strong>After</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c437238f-0b11-4117-92b3-94ec067f6314" alt="Before" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/de75c753-7e5b-4073-8f48-9d364c8059bd" alt="After" width="400"></td>
  </tr>
</table>
