### PR TITLE
[resolved issue #118] enable the light & dark  mode

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -17,7 +17,7 @@
 theme = "minimal"
 
 # Enable users to switch between day and night mode?
-day_night = false
+day_night = true
 
 # Override the theme's font set (optional).
 #   Latest font sets (may require updating): https://sourcethemes.com/academic/themes/


### PR DESCRIPTION
why need : 

Whenever my computer's default theme is dark, the page switches to dark mode after refreshing or clicking any link, requiring manual adjustment to light mode each time. This issue affected readability and user experience.

before : 

[Screencast from 28-01-25 07:59:36 AM IST.webm](https://github.com/user-attachments/assets/df2881f0-8cd1-47f5-8dce-c3504024519d)

after : 

[Screencast from 28-01-25 08:05:39 AM IST.webm](https://github.com/user-attachments/assets/4d1be290-b152-4023-87c2-3d4d958a5023)

issue Resolved : #118 
