### PR TITLE
Updated the Font Awesome CDN version and twitter logo

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -35,7 +35,7 @@
     weight = 10
 
   [[zh.menu.main_right]]
-    name = "<i class=\"fab fa-twitter\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+    name = "<i class=\"fab fa-x-twitter\" style=\"font-size: 1rem; line-height: 1.25\"></i>"
     post = ""
     url = "https://twitter.com/Kmesh_net"
     weight = 20

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -47,7 +47,7 @@
   #  weight = 30
 
   [[zh.menu.main_right]]
-    name = "<i class=\"fab fa-weixin\" style=\"color: #55acee; font-size: 1rem; line-height: 1.25\"></i>"
+    name = "<i class=\"fab fa-weixin\" style=\"color: #1AAD19; font-size: 1rem; line-height: 1.25\"></i>"
     post = ""
     url = "https://blog.51cto.com/u_15127420/4992806"
     weight = 40

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -29,7 +29,7 @@
 
 # Right Menu
   [[zh.menu.main_right]]
-    name = "<i class=\"fab fa-github-alt\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
+    name = "<i class=\"fab fa-github\" style=\"color: #333; font-size: 1rem; line-height: 1.25\"></i>"
     post = ""
     url = "https://github.com/kmesh-net/kmesh"
     weight = 10

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -31,7 +31,7 @@
   weight = 10
 
 [[main_right]]
-  name = "<i class=\"fab fa-twitter\" style=\"color: #1DA1F2; font-size: 1rem; line-height: 1.25\"></i>"
+  name = "<i class=\"fab fa-x-twitter\" style=\"font-size: 1rem; line-height: 1.25\"></i>"
   post = ""
   url = "https://twitter.com/Kmesh_net"
   weight = 20

--- a/themes/academic/data/assets.toml
+++ b/themes/academic/data/assets.toml
@@ -77,8 +77,8 @@
 # CSS
 
 [css.fontAwesome]
-  version = "5.14.0"
-  sri = "sha256-FMvZuGapsJLjouA6k7Eo2lusoAX9i0ShlWFG6qt7SLc="
+  version = "6.7.2"
+  sri = "sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
   url = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/%s/css/all.min.css"
 [css.academicons]
   version = "1.8.6"


### PR DESCRIPTION
### Description
The website used an outdated version of Font Awesome for using brand icons. This Pull Request aims to update the Font Awesome CDN version and respective SRI hash. Now, the website can use newer font awesome icons easily.

The PR also updates the old Twitter logo to the new X logo. This makes the site up to date.

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/e9006a26-c623-44b2-97de-0b4ddfd02fea)

After:
![image](https://github.com/user-attachments/assets/88202df6-9412-4c8f-9782-464bea270afe)

### Checklist
- [x] I have performed a self-review of my code (by locally developing the site).
- [x] My fork of the repository is updated.

#### Related to issue #115 