### PR TITLE
Enable Dark Mode Toggle

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -17,7 +17,7 @@
 theme = "minimal"
 
 # Enable users to switch between day and night mode?
-day_night = false
+day_night = true
 
 # Override the theme's font set (optional).
 #   Latest font sets (may require updating): https://sourcethemes.com/academic/themes/


### PR DESCRIPTION
#### **What this PR does:**  
Currently, the website does not support dark mode, which can be a strain on the eyes, especially in low-light environments. This PR introduces a dark mode toggle feature, ensuring a better user experience by allowing users to switch themes seamlessly.  

## Related Issue
- Fixes *#118*.

#### **Before:**  
- The website only had a light theme.  
- No option to toggle between light and dark modes.  

![image](https://github.com/user-attachments/assets/a5765900-b2e6-4439-8c58-dc2ec6c88374)



#### **After:**  
- A dark mode toggle button is added to the navbar.  
- The selected theme preference is saved and applied on reload.  
- Improved accessibility and user experience.  
![image](https://github.com/user-attachments/assets/e50802ce-bf54-4fb1-a690-7079907fc6ac)

