### PR TITLE
Fixes the title attribute in Documentation and Architecture pages

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,4 +1,5 @@
 ---
+title: "Documentation"
 date: 2023-07-07
 draft: false
 lastmod: 2023-04-23

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Documentation"
+title: Documentation
 date: 2023-07-07
 draft: false
 lastmod: 2023-04-23

--- a/content/en/docs/architecture/_index.md
+++ b/content/en/docs/architecture/_index.md
@@ -1,4 +1,5 @@
 ---
+title: Architecture
 draft: false
 menu:
   docs:


### PR DESCRIPTION
### Description
The Kmesh `Documentation` and `Architecture` pages lacked a title attribute in their front matter, which resulted in an empty view in the page title. The Pull Request focuses on fixing the issue.

### screenshots
Before:
![Screenshot 2025-02-08 033705](https://github.com/user-attachments/assets/146960fb-eb1f-4f52-8e9f-6d26d69cb7dd)

After:
![Screenshot 2025-02-08 033633](https://github.com/user-attachments/assets/de1b585f-9bdc-4b96-af42-e4f6e16a6921)

- [x] I have signed off my commits using `git -s`