### PR TITLE
Fix sidebar confusion on doc pages

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -67,7 +67,7 @@
 [[docs]]
   name = "User Guide"
   weight = 16
-  identifier = "user_guide"
+  identifier = "user guide"
 
 [[docs]]
   name = "Performance"
@@ -77,7 +77,7 @@
 [[docs]]
   name = "Developer Guide"
   weight = 25
-  identifier = "developer_guide"
+  identifier = "developer guide"
 
 [[docs]]
   name = "Community"


### PR DESCRIPTION
Fix sidebar confusion on doc pages
before:
![image](https://github.com/user-attachments/assets/febf02f5-1b56-4871-a1d7-4dd4e5b22ca6)
