### PR TITLE
fix(docs): fix performance doc broken-link

### DIFF
--- a/docs/performance/performance.md
+++ b/docs/performance/performance.md
@@ -30,7 +30,7 @@ Kmesh uses two main testing tools:
 
 ### Test Method
 
-Test a group of `fortio` performance data by using the number of concurrent connections as a variable parameter, and collect the CPU usage during the test. The [test script](https://github.com/kmesh-net/kmesh/test/performance/) has been archived.
+Test a group of `fortio` performance data by using the number of concurrent connections as a variable parameter, and collect the CPU usage during the test. The [test script](https://github.com/kmesh-net/kmesh/tree/main/test/performance) has been archived.
 
 ## Running the Tests
 


### PR DESCRIPTION
- I fixed broken link of performance docs 

After:

<img width="1297" alt="Screenshot 2025-06-08 at 11 17 11 PM" src="https://github.com/user-attachments/assets/f6ac3c47-9a7f-4c82-9e96-52c7cf7214f1" />

Before:

<img width="1710" alt="Screenshot 2025-06-08 at 11 17 45 PM" src="https://github.com/user-attachments/assets/5e6fae38-00e0-4542-8023-1bde0e6c0b46" />