### PR TITLE
fix(readme): Readme docs broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo contains the source code of [Kmesh Website](https://kmesh.net/en/) and all of the docs for Kmesh.
 
 - [Kmesh Website](https://kmesh.net/en/)
-- [Kmesh Docs](https://kmesh.net/en/docs/)
+- [Kmesh Docs](https://kmesh.net/docs/welcome)
 - [Kmesh Blog](https://kmesh.net/en/blog/)
 
 Welcome to join us and you are more than appreciated to contribute!


### PR DESCRIPTION
fix readme (kmesh docs) broken link.

Before:
<img width="1710" alt="Screenshot 2025-06-30 at 10 23 10 PM" src="https://github.com/user-attachments/assets/ca752686-342e-42c2-aa73-5fea3c78ae71" />

After:
<img width="1710" alt="Screenshot 2025-06-30 at 10 24 38 PM" src="https://github.com/user-attachments/assets/805f0060-563f-473f-b10f-264ae53692e8" />

