### PR TITLE
docs: improve versioned Helm chart installation instructions

### DIFF
--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -90,10 +90,9 @@ We offer several ways to install Kmesh:
 You can install Kmesh directly from the GitHub Container Registry without cloning the repository:
 
 ```shell
-kubectl create namespace kmesh-system
-helm install kmesh oci://ghcr.io/kmesh-net/kmesh-helm --version x.y.z -n kmesh-system
+helm install kmesh oci://ghcr.io/kmesh-net/kmesh-helm --version x.y.z -n kmesh-system --create-namespace
 ```
-Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm).(example: `v1.1.0`)
+Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm).(e.g., `v1.1.0`)
 
 ### Option 2: Install from Helm
 

--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -92,15 +92,25 @@ You can install Kmesh directly from the GitHub Container Registry without clonin
 ```shell
 helm install kmesh oci://ghcr.io/kmesh-net/kmesh-helm --version x.y.z -n kmesh-system --create-namespace
 ```
-Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm)(e.g., `v1.1.0`).
+- Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm):
+  - Use --version v1.1.0 for stable releases
+  - Use --version v1.1.0-alpha for pre-releases
+  - Omit --version to install the latest version (not recommended for production)
 
 ### Option 2: Install from Helm
 
 ```shell
 helm install kmesh ./deploy/charts/kmesh-helm -n kmesh-system --create-namespace
 ```
+### Option 3: Install from Helm Chart Archive
 
-### Option 3: Install from Yaml
+```shell
+helm install kmesh ./kmesh-helm-<version>.tgz -n kmesh-system --create-namespace
+```
+- Replace `<version>` with your desired version from  [GitHub Releases](https://github.com/kmesh-net/kmesh/releases):
+
+
+### Option 4: Install from Yaml
 
 ```shell
 kubectl create namespace kmesh-system

--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -85,13 +85,23 @@ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
 
 We offer several ways to install Kmesh:
 
-### Option 1: Install from Helm
+### Option 1: Install from OCI Registry (Recommended)
+
+You can install Kmesh directly from the GitHub Container Registry without cloning the repository:
+
+```shell
+kubectl create namespace kmesh-system
+helm install kmesh oci://ghcr.io/kmesh-net/kmesh-helm --version x.y.z -n kmesh-system
+```
+Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm).(example: `v1.1.0`)
+
+### Option 2: Install from Helm
 
 ```shell
 helm install kmesh ./deploy/charts/kmesh-helm -n kmesh-system --create-namespace
 ```
 
-### Option 2: Install from Yaml
+### Option 3: Install from Yaml
 
 ```shell
 kubectl create namespace kmesh-system
@@ -277,7 +287,7 @@ Annotations:      <none>
 
 ### Delete Kmesh
 
-If you installed Kmesh using helm:
+If you installed Kmesh using helm or OCI registry:
 
 ```shell
 helm uninstall kmesh -n kmesh-system

--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -92,7 +92,7 @@ You can install Kmesh directly from the GitHub Container Registry without clonin
 ```shell
 helm install kmesh oci://ghcr.io/kmesh-net/kmesh-helm --version x.y.z -n kmesh-system --create-namespace
 ```
-Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm).(e.g., `v1.1.0`)
+Replace `x.y.z` with your desired version from [kmesh-helm packages](https://github.com/orgs/kmesh-net/packages/container/package/kmesh-helm)(e.g., `v1.1.0`).
 
 ### Option 2: Install from Helm
 


### PR DESCRIPTION
- Simplify tarball installation syntax using <version> placeholder
- Add clear examples for stable/pre-release version patterns
- Maintain reference to GitHub Releases page
- Keep consistent with OCI installation format

Resolves: #181"