### PR TITLE
feat(slider): add clickable link in subTitle and key for CNCF image switch

### DIFF
--- a/src/components/CNCFInfo/index.js
+++ b/src/components/CNCFInfo/index.js
@@ -25,6 +25,7 @@ export default function CNCFInfo() {
             src={colorMode === 'dark' ? "/img/cncf-dark.svg" : "/img/cncf-light.svg"} 
             alt="CNCF Logo" 
             className={styles.logoImage}
+            key={colorMode}
           />
         </div>
       </div>

--- a/src/components/slider/index.js
+++ b/src/components/slider/index.js
@@ -22,7 +22,14 @@ const sliderItems = [
         The forwarding delay of the service mesh is reduced by 5x
       </Translate>
     ),
-    subTitle: <Translate>click here for more Details</Translate>,
+    subTitle: (
+      <a
+        href="https://kmesh.net/docs/welcome"
+        style={{ color: 'inherit', textDecoration: 'underline' }}
+      >
+        <Translate>Click here for more Details</Translate>
+      </a>
+    ),
     backgroundImage: "img/headers/bubbles-wide.jpg",
     opacity: 0.5,
     align: "center",


### PR DESCRIPTION
- Made "click here for more Details" text a clickable link
- Added key prop to enable quick switching of CNCF image based on dark/light mode
