### PR TITLE
fix kmeshctl-secret linktitle error

### DIFF
--- a/docs/developer-guide/Kmeshctl-usage/kmeshctl-secret.md
+++ b/docs/developer-guide/Kmeshctl-usage/kmeshctl-secret.md
@@ -1,14 +1,6 @@
 ---
-draft: true
-linktitle: Use IPsec in Kmesh cluster
-menu:
-  docs:
-    parent: user guide
-    weight: 21
-title: Use IPsec in Kmesh cluster
-toc: true
-type: docs
-
+linktitle: kmeshctl secret
+sidebar_position: 6
 ---
 
 ### Use IPsec in Kmesh cluster


### PR DESCRIPTION
fix kmesh-secret,md linktitle error, which cause kmeshcrl secret page missing on kmesh website