### PR TITLE
fix: use correct markdown syntax for reference links in release notes

### DIFF
--- a/blog/kmesh-1.1-release/index.md
+++ b/blog/kmesh-1.1-release/index.md
@@ -95,6 +95,6 @@ We have always developed Kmesh with an open and neutral attitude, and continue t
 
 ## Reference Links
 
-* Kmesh Release v1.1.0（https://github.com/kmesh-net/kmesh/releases/tag/v1.1.0）
-* Kmesh GitHub（https://github.com/kmesh-net/kmesh）
-* Kmesh Website（https://kmesh.net/）
+* [Kmesh Release v1.1.0](https://github.com/kmesh-net/kmesh/releases/tag/v1.1.0)
+* [Kmesh GitHub](https://github.com/kmesh-net/kmesh)
+* [Kmesh Website](https://kmesh.net/)


### PR DESCRIPTION
fixes:  #228