### PR TITLE
feature(workflow): added versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,50 @@
+name: Docusaurus Versioning
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create-version-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git operations
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # Adjust if your project uses a different version
+
+      - name: Install dependencies
+        run: npm install  # Use npm install since package-lock.json is not available
+
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run Docusaurus versioning
+        run: npx docusaurus docs:version ${{ steps.extract_version.outputs.version }}
+
+      - name: Create branch and commit changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          BRANCH="version-${{ steps.extract_version.outputs.version }}"
+          git checkout -b $BRANCH
+          git add .
+          git commit -m "Add Docusaurus version ${{ steps.extract_version.outputs.version }}" || echo "No changes to commit"
+          git push origin $BRANCH
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="version-${{ steps.extract_version.outputs.version }}"
+          gh pr create --base main --head $BRANCH --title "Add version ${{ steps.extract_version.outputs.version }}" --body "Automated versioning changes for v${{ steps.extract_version.outputs.version }}. This includes English docs; Chinese will fallback to English as per Docusaurus behavior."


### PR DESCRIPTION
This PR addresses the issue in https://github.com/kmesh-net/kmesh/issues/1412

This PR introduces and documents an automated versioning workflow for our Docusaurus documentation site using GitHub Actions. The goal is to automatically create versioned documentation branches whenever a new Git tag prefixed with v (e.g., v1.2.0) is pushed to the repository.

### This ensures that:

- Each released version of the product has a dedicated snapshot of its documentation.
- Users can access historical documentation via the Docusaurus version dropdown.
- Maintenance of past versions is streamlined and consistent.

### How to Use: 

1.  Tag a release: `git tag v1.2.0 && git push origin v1.2.0`
2. Wait for the action to run
3. Review and merge the auto-created PR

### Permissions:

- The workflow uses `secrets.GITHUB_TOKEN` to create branches and PRs.
- Ensure the repo allows GitHub Actions to create pull requests (default in public repos; may require approval in private/org repos).

### Important Considerations:

**1. Supported Tag Format:**

- Tags must follow the format` vX.Y.Z` (e.g., v1.0.0, v2.3.4-alpha).
- Tags like release-1.0 or 1.0.0 (without v) will not trigger the workflow.

**2. Multi-Language Support:**

- Currently, only English (en) documentation is versioned.
- Chinese (zh) and other locales will fallback to English content for older versions, per Docusaurus default behavior.
- If localized versions are needed in the future, manual intervention or additional automation will be required.

**3. Conflicts & Manual Fixes:**

- If two version tags are created rapidly, race conditions may occur.
- If the PR shows unexpected changes (e.g., unrelated files), investigate possible merge drift or uncommitted local changes at time of tagging.

**4. Do Not Run Locally:**

- Avoid running `docusaurus docs:version` manually unless absolutely necessary.
- Doing so may cause conflicts with the automated flow or inconsistent version metadata.