### PR TITLE
feature(404): Added Custom 404 Page

### DIFF
--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,82 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import styles from "./styles.module.css"; // we will create this next
+
+export default function NotFoundContent({ className }) {
+  return (
+    <main className={className}>
+      <div className={styles.pageWrapper}>
+        <div className={styles.notFoundContainer}>
+          <div className={styles.content}>
+            <h1 className={styles.title}>Page Not Found</h1>
+            <p className={styles.subtitle}>
+              The requested resource could not be located on this server.
+            </p>
+
+            <div className={styles.messageBox}>
+              <div className={styles.infoIcon}>
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className={styles.message}>
+                  Chinese documentation is currently unavailable.
+                </p>
+                <p className={styles.message}>
+                  Please refer to our{" "}
+                  <Link to="/docs/welcome" className={styles.link}>
+                    English documentation
+                  </Link>{" "}
+                  for comprehensive project information.
+                </p>
+              </div>
+            </div>
+
+            <div className={styles.actions}>
+              <Link to="/" className={styles.primaryButton}>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+                    fill="currentColor"
+                  />
+                </svg>
+                Return Home
+              </Link>
+              <Link to="/docs/welcome" className={styles.secondaryButton}>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                View Documentation
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/NotFound/Content/styles.module.css
+++ b/src/theme/NotFound/Content/styles.module.css
@@ -1,0 +1,195 @@
+.pageWrapper {
+  min-height: 100vh;
+  width: 100%;
+}
+
+/* Replaced gradient background with professional blue-grey theme */
+.notFoundContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 2rem;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  position: relative;
+}
+
+/* Replaced bouncing animation with clean, professional error display */
+.errorSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 3rem;
+}
+
+.errorCode {
+  font-size: 5rem;
+  font-weight: 700;
+  color: #475569;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+  font-family: "SF Mono", "Monaco", "Inconsolata", "Roboto Mono", monospace;
+}
+
+.errorIcon {
+  color: #64748b;
+  opacity: 0.7;
+}
+
+/* Updated content styling with professional blue-grey color scheme */
+.content {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 3rem 2rem;
+  box-shadow: 0 10px 25px rgba(71, 85, 105, 0.1);
+  max-width: 600px;
+  width: 100%;
+}
+
+.title {
+  font-size: 2.25rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.75rem;
+}
+
+.subtitle {
+  font-size: 1.125rem;
+  color: #64748b;
+  margin-bottom: 2.5rem;
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+/* Updated message box with professional styling and blue accent */
+.messageBox {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  border-left: 4px solid #36b4f3;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 2.5rem;
+  text-align: left;
+}
+
+.infoIcon {
+  color: #36b4f3;
+  flex-shrink: 0;
+  margin-top: 0.5rem;
+}
+
+.message {
+  font-size: 1rem;
+  color: #475569;
+  margin: 0.25rem 0;
+  line-height: 1.6;
+}
+
+/* Updated link styling with professional blue color */
+.link {
+  color: #3b82f6 !important;
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.link:hover {
+  border-bottom-color: #3b82f6;
+  text-decoration: none !important;
+}
+
+/* Redesigned buttons with professional blue-grey theme */
+.actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.5rem;
+  border-radius: 8px;
+  font-size: 0.975rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+
+.primaryButton:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: white;
+  text-decoration: none;
+}
+
+.secondaryButton {
+  background: white;
+  color: #475569;
+  border-color: #cbd5e1;
+}
+
+.secondaryButton:hover {
+  background: #f8fafc;
+  border-color: #94a3b8;
+  color: #334155;
+  text-decoration: none;
+}
+
+/* Updated responsive design for mobile devices */
+@media (max-width: 768px) {
+  .notFoundContainer {
+    padding: 1rem;
+  }
+
+  .infoIcon {
+    display: none;
+  }
+
+  .errorCode {
+    font-size: 5rem;
+  }
+
+  .content {
+    padding: 2rem 1.5rem;
+  }
+
+  .title {
+    font-size: 1.875rem;
+  }
+
+  .messageBox {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.75rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+    max-width: 280px;
+    justify-content: center;
+  }
+}

--- a/src/theme/NotFound/index.js
+++ b/src/theme/NotFound/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+export default function Index() {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
- Replaces the stock Docusaurus “Page Not Found” screen with a branded, user-friendly 404 page that guides visitors back to the documentation or home page.

### How

- Swizzled @docusaurus/theme-classic NotFound (--eject)
-Updated src/theme/NotFound/Content/index.js with new markup and SVG icons
-Added professional blue-grey styling in src/theme/NotFound/Content/styles.module.css
- Fully responsive & accessible (WCAG 2.1 AA colours)


<img width="1694" height="982" alt="Screenshot 2025-09-06 at 1 06 09 PM" src="https://github.com/user-attachments/assets/e8b9da07-c5c4-48a0-904a-be942b0e3057" />
