### PR TITLE
Fix: Specify Istio version for Waypoint feature

### DIFF
--- a/docs/setup/develop-with-kind.md
+++ b/docs/setup/develop-with-kind.md
@@ -42,7 +42,7 @@ EOF
 ### Install istioctl
 
 ```shell
-ISTIO_VERSION="1.24.0"
+ISTIO_VERSION="1.24.0" # If you wish to use the Waypoint feature, the Istio version should be 1.23 ~ 1.25.
 
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" sh - && \
 cd "istio-${ISTIO_VERSION}/bin" && \

--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -15,7 +15,7 @@ Before installing Kmesh, ensure your environment meets the following requirement
 | Requirement | Version | Notes                 |
 | ----------- | ------- | --------------------- |
 | Kubernetes  | 1.26+   | Tested on 1.26-1.29   |
-| Istio       | 1.22+   | Ambient mode required |
+| Istio       | 1.22+   | Tested on 1.22-1.25 (ambient mode required) |
 | Helm        | 3.0+    | For helm installation |
 | Memory      | 4GB+    | Recommended minimum   |
 | CPU         | 2 cores | Recommended minimum   |
@@ -69,10 +69,10 @@ helm install istio-base istio/base -n istio-system
 To install the chart with the release name `istiod`:
 
 ```shell
-helm install istiod istio/istiod --namespace istio-system --version 1.25.0 --set pilot.env.PILOT_ENABLE_AMBIENT=true
+helm install istiod istio/istiod --namespace istio-system --version 1.24.0 --set pilot.env.PILOT_ENABLE_AMBIENT=true
 ```
 
-> **Important:** Must set `pilot.env.PILOT_ENABLE_AMBIENT=true`. otherwise Kmesh will not be able to establish grpc links with istiod! If you want to use the Waypoint feature, the istio version should not be higher than 1.25.
+> **Important:** Must set `pilot.env.PILOT_ENABLE_AMBIENT=true`. otherwise Kmesh will not be able to establish grpc links with istiod! If you want to use the Waypoint feature, you should use the istio version 1.23 ~ 1.25.
 
 After installing istiod, it's time to install Kubernetes Gateway API CRDs.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/setup/develop-with-kind.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/setup/develop-with-kind.md
@@ -42,17 +42,13 @@ EOF
 ### 安装 istioctl
 
 ```shell
-ISTIO_VERSION="1.24.0"
+ISTIO_VERSION="1.24.0" # 如果您希望使用 Waypoint 功能，istio 版本应该为 1.23 ~ 1.25
 
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" sh - && \
 cd "istio-${ISTIO_VERSION}/bin" && \
 chmod +x istioctl && \
 mv istioctl /usr/bin/
 ```
-
-:::note
-如果您希望使用 Waypoint 功能，istio 版本不应该高于 1.25
-:::
 
 ### 使用 istioctl 安装 istio 组件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/setup/quick-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/setup/quick-start.md
@@ -15,7 +15,7 @@ sidebar_position: 1
 | 要求       | 版本  | 备注                    |
 | ---------- | ----- | ----------------------- |
 | Kubernetes | 1.26+ | 在 1.26-1.29 上测试通过 |
-| Istio      | 1.22+ | 需要环境模式            |
+| Istio      | 1.22+ | 在 1.23-1.25 上测试通过 (需要环境模式) |
 | Helm       | 3.0+  | 用于 helm 安装          |
 | 内存       | 4GB+  | 建议最小配置            |
 | CPU        | 2 核  | 建议最小配置            |
@@ -69,10 +69,10 @@ helm install istio-base istio/base -n istio-system
 使用发布名称 `istiod` 安装图表：
 
 ```shell
-helm install istiod istio/istiod --namespace istio-system --version 1.25.0 --set pilot.env.PILOT_ENABLE_AMBIENT=true
+helm install istiod istio/istiod --namespace istio-system --version 1.24.0 --set pilot.env.PILOT_ENABLE_AMBIENT=true
 ```
 
-> **重要：** 必须设置 `pilot.env.PILOT_ENABLE_AMBIENT=true`。否则 Kmesh 将无法与 istiod 建立 grpc 链接！ 如果想要使用 Waypoint 功能，istio 版本应不高于 1.25。
+> **重要：** 必须设置 `pilot.env.PILOT_ENABLE_AMBIENT=true`。否则 Kmesh 将无法与 istiod 建立 grpc 链接！ 如果想要使用 Waypoint 功能，您的 istiod 版本应该为 1.23~1.25。
 
 安装 istiod 后，是时候安装 Kubernetes Gateway API CRD 了。
 


### PR DESCRIPTION
Set the Istio version to 1.24.0 to ensure compatibility with the Waypoint feature and provide a note regarding version limitations.