### PR TITLE
fix(ui): clean navbar for tablet view & responsive slider text

### DIFF
--- a/src/components/About/styles.scss
+++ b/src/components/About/styles.scss
@@ -67,6 +67,70 @@
       margin: 0px 0 10px 0;
     }
   }
+
+  @media (max-width: 435px) {
+    .row {
+      .description {
+        flex: 0 0 66.666667%;
+        max-width: 66.666667%;
+        font-size: 1rem;
+      }
+
+      .name {
+        font-size: 1.5em;
+        font-weight: 400;
+        margin: 20px 0 10px 0;
+      }
+
+      .jobTitle {
+        font-size: 0.5rem;
+        font-weight: 300;
+        margin: 0px 0 10px 0;
+      }
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .row {
+      .description {
+        font-size: 1rem;
+      }
+      .name {
+        font-size: 1.5em;
+      }
+      .jobTitle {
+        font-size: 0.7rem;
+      }
+    }
+  }
+
+  @media (min-width: 1300px) and (max-width: 1515px) {
+    .row {
+      .description {
+        font-size: 1.1rem;
+      }
+      .name {
+        font-size: 1.8em;
+      }
+      .jobTitle {
+        font-size: 0.9rem;
+      }
+    }
+  }
+
+  @media (max-width: 1300px) {
+    .row {
+      .description {
+        font-size: 1.1rem;
+      }
+      .name {
+        font-size: 1.8em;
+      }
+      .jobTitle {
+        font-size: 0.9rem;
+      }
+    }
+  }
 }
 
 html[data-theme="dark"] {

--- a/src/components/slider/index.scss
+++ b/src/components/slider/index.scss
@@ -19,24 +19,18 @@
 
       &.left {
         align-items: flex-start;
-
         .title {
           text-align: left;
         }
       }
-
       &.right {
         align-items: flex-end;
-
         .title {
           text-align: right;
         }
       }
-
       &.center {
-        align-items: centers;
-        justify-content: center;
-
+        align-items: center;
         .title {
           text-align: center;
         }
@@ -46,26 +40,23 @@
         color: white;
       }
 
-      .button {
-        a {
-          display: block;
-          cursor: pointer;
-          font-size: 1.1rem;
-          font-weight: 400;
-          color: #0039cb;
-          padding: 0.5em 2.1em;
-          background-color: #f8f9fa;
-          border-color: #f8f9fa;
-          border-radius: 0.4rem;
-          text-decoration: none;
-          user-select: none;
-          transition: color 0.15s ease-in-out,
-            background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
-
-          &:hover {
-            background-color: #e2e6ea;
-            border-color: #dae0e5;
-          }
+      .button a {
+        display: block;
+        cursor: pointer;
+        font-size: 1.1rem;
+        font-weight: 400;
+        color: #0039cb;
+        padding: 0.5em 2.1em;
+        background-color: #f8f9fa;
+        border-color: #f8f9fa;
+        border-radius: 0.4rem;
+        text-decoration: none;
+        user-select: none;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+          border-color 0.15s ease-in-out;
+        &:hover {
+          background-color: #e2e6ea;
+          border-color: #dae0e5;
         }
       }
 
@@ -73,7 +64,6 @@
         font-size: 2.7rem;
         text-align: inherit;
       }
-
       .sub-title {
         font-size: 1.35rem;
         text-align: inherit;
@@ -85,30 +75,68 @@
       width: 15%;
       z-index: 1;
     }
-
     .slick-prev {
-      position: position;
       left: 0;
     }
-
     .slick-next {
-      position: position;
       right: 0;
     }
-
     .slick-dots {
       bottom: 10px;
     }
   }
 
-  @media (max-width: 768px) {
-    .slick-slider {
-      .slick-item {
-        padding-right: 20px;
-        padding-left: 20px;
-        margin: 0 0.25rem;
+  @media (max-width: 1230px) and (min-width: 993px){
+    .slick-slider .slick-item {
+      .main-title {
+        font-size: 2rem;
       }
+      .sub-title {
+        font-size: 1.3rem;
+      }
+    }
+  }
 
+  @media (max-width: 992px) {
+    .slick-slider .slick-item {
+      .main-title {
+        font-size: 2rem;
+      }
+      .sub-title {
+        font-size: 1.3rem;
+      }
+    }
+  }
+
+  @media (max-width: 768px) and (min-width: 565px) {
+    .slick-slider .slick-item {
+      .main-title {
+        font-size: 1.4rem;
+      }
+      .sub-title {
+        font-size: 1rem;
+      }
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  @media (max-width: 564px) {
+    .slick-slider .slick-item {
+      .main-title {
+        font-size: 1.4rem;
+      } 
+      .sub-title {
+        font-size: 1rem;
+      }
+    }
+  }
+
+  @media (max-width: 768px) {
+    .slick-slider .slick-item {
+      padding-right: 20px;
+      padding-left: 20px;
+      margin: 0 0.25rem;
       .title {
         text-align: center;
       }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -130,3 +130,41 @@
   width: 100%;
   height: 100%;
 }
+
+/* 997 px – 1245 px : ONLY logo + toggle + search */
+@media (min-width: 997px) and (max-width: 1245px) {
+  /* hide all navbar links except the logo image */
+  .navbar__item:not(.navbar__logo):not(img),
+  .navbar__link:not(.navbar__logo):not(img) {
+    display: none !important;
+  }
+
+  /* make sure logo, toggle, search stay visible */
+  .navbar__logo,
+  .navbar__logo img,
+  .navbar__toggle,
+  .navbar__search,
+  .DocSearch-Button {
+    display: inline-block !important;
+  }
+
+  /* push logo to the far left */
+  .navbar__brand {
+    margin-right: auto;
+  }
+
+  /* tidy sizes */
+  .navbar__logo { height: 1.8rem; }
+  .navbar__title { font-size: 1.1rem; }
+}
+
+/* mobile sidebar : social icons in a ROW */
+@media (max-width: 996px) {
+  .navbar-sidebar__items .navbar__items--right,
+  .navbar-sidebar__items .navbar__items--right .navbar__item {
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 0.75rem;          /* space between icons */
+    align-items: center;
+  }
+}


### PR DESCRIPTION
### Output after the fixes
- Navbar stays single-line between 997 px and 1245 px: logo on the far left, search and hamburger on the right; no more wrapped or hidden items.
- Slider headings and subtitles now shrink smoothly on tablets and phones, so they remain readable without breaking the layout or overflowing the screen.

### Benefit for the website
- Visitors on laptops, iPads and large phones get a clean, professional header and hero section that adapts instantly to their screen size—reducing bounce rate and improving overall user experience.

Before : 
<img width="1179" height="71" alt="Screenshot 2025-10-28 at 11 38 10 PM" src="https://github.com/user-attachments/assets/77cf7386-8a01-40a9-ad7c-cec275524a2f" />

After : 
<img width="1131" height="72" alt="Screenshot 2025-10-28 at 11 39 00 PM" src="https://github.com/user-attachments/assets/19b7d40e-a538-40d3-b0c1-5d2fde047eb6" />

Before:
<img width="640" height="418" alt="Screenshot 2025-10-28 at 11 39 37 PM" src="https://github.com/user-attachments/assets/28c54aaa-8e2f-4f45-8ffe-c338b61cc1cf" />

After: 
<img width="493" height="424" alt="Screenshot 2025-10-28 at 11 40 58 PM" src="https://github.com/user-attachments/assets/2e9ec4ae-07c1-44a8-9c23-d855afdbc303" />



