### PR TITLE
fix: display missing date in recent news section (#257)

### DIFF
--- a/src/components/Blogs/index.js
+++ b/src/components/Blogs/index.js
@@ -3,52 +3,68 @@ import { usePluginData } from "@docusaurus/useGlobalData";
 import SectionContainer from "../sectionContainer";
 import { useHistory } from "@docusaurus/router";
 import Translate from "@docusaurus/Translate";
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import "./styles.scss";
 
 export default function Blogs() {
-  const {
-    blogGlobalData: { blogPosts },
-  } = usePluginData("blog-global-dataPlugin");
 
-  const history = useHistory();
+    const { i18n: { currentLocale } } = useDocusaurusContext();
 
-  return (
-    <SectionContainer className="blogPostContainer">
-      <div className="row">
-        <div className="left">
-          <h1>
-            <Translate>Recent News</Translate>
-          </h1>
-          <a onClick={() => history.push("blog")}>
-            <Translate>View All</Translate>
-          </a>
-        </div>
-        <div className="right">
-          {blogPosts.slice(0, 3).map((item, index) => (
-            <div key={index} className="viewBlogContainer">
-              <h3 onClick={() => history.push(item.metadata.permalink)}>
-                {item.metadata.title}
-              </h3>
-              {item.metadata?.frontMatter?.summary && (
-                <p>{item.metadata?.frontMatter.summary}</p>
-              )}
-              <div className="info">
-                <div className="author">
-                  {(item.metadata?.authors || []).map((item) => (
-                    <a href={item.url} target="_blank">
-                      {item.name}
+    const {
+        blogGlobalData: { blogPosts },
+    } = usePluginData("blog-global-dataPlugin");
+
+    const history = useHistory();
+
+    return (
+        <SectionContainer className="blogPostContainer">
+            <div className="row">
+                <div className="left">
+                    <h1>
+                        <Translate>Recent News</Translate>
+                    </h1>
+                    <a onClick={() => history.push("blog")}>
+                        <Translate>View All</Translate>
                     </a>
-                  ))}
                 </div>
-                <div className="update-time">
-                  <Translate>Last updated on</Translate>{" "}
-                  {item.metadata.formattedDate}
+                <div className="right">
+                    {blogPosts.slice(0, 3).map((item, index) => (
+                        <div key={index} className="viewBlogContainer">
+                            <h3
+                                onClick={() =>
+                                    history.push(item.metadata.permalink)
+                                }
+                            >
+                                {item.metadata.title}
+                            </h3>
+                            {item.metadata?.frontMatter?.summary && (
+                                <p>{item.metadata?.frontMatter.summary}</p>
+                            )}
+                            <div className="info">
+                                <div className="author">
+                                    {(item.metadata?.authors || []).map(
+                                        (item) => (
+                                            <a href={item.url} target="_blank">
+                                                {item.name}
+                                            </a>
+                                        )
+                                    )}
+                                </div>
+                                <div className="update-time">
+                                    <Translate>Last updated on</Translate>{" "}
+                                    {new Date(
+                                        item.metadata.date
+                                    ).toLocaleDateString(currentLocale, {
+                                        year: "numeric",
+                                        month: "long",
+                                        day: "numeric",
+                                    })}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
                 </div>
-              </div>
             </div>
-          ))}
-        </div>
-      </div>
-    </SectionContainer>
-  );
+        </SectionContainer>
+    );
 }


### PR DESCRIPTION
### Description
This PR fixes the issue where the "Last updated on" date was not showing in the **Recent News** section on the homepage.

The previous code was attempting to access `item.metadata.formattedDate`, which was undefined in the blog post data. I have updated the code to use `item.metadata.date` and format it using `toLocaleDateString` to ensure it displays correctly.

### Related Issue
Fixes #257

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

### How Has This Been Tested?
I ran the website locally using `npm start` and verified that the dates now appear correctly in the Recent News list.

**Screenshots:**

<img width="1451" height="721" alt="image" src="https://github.com/user-attachments/assets/6e0ee6af-4240-4235-9e33-eee1366490f6" />