### PR TITLE
feat(docs): add version selector dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,11 @@ const config = {
             position: "left",
             label: "Documentation",
           },
+          {
+            type: "docsVersionDropdown",
+            position: "left",
+            dropdownActiveClassDisabled: true,
+          },
           { to: "/blog", label: "Blog", position: "left" },
           {
             href: "https://github.com/kmesh-net/kmesh/releases",


### PR DESCRIPTION
Fixes #147

Added docsVersionDropdown navbar item to enable users to select and view documentation for their specific Kmesh version.

Changes:
- Added version dropdown between Documentation and Blog navbar items
- Uses Docusaurus native versioning feature