### PR TITLE
Add build workflow in Github action 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Codespell
+name: Website CI
 
 on:
   push:
@@ -10,6 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  build:
+    name: Build Docusaurus
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install
+      - name: Build Docusaurus
+        run: npm run build
+        env:
+          GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,8 @@
 
 import { themes as prismThemes } from "prism-react-renderer";
 
+const gaTrackingID = process.env.GA_TRACKING_ID;
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Kmesh",
@@ -43,10 +45,12 @@ const config = {
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },
-        gtag: {
-          trackingID: "G-854W8PEZ1Z",
-          anonymizeIP: true,
-        },
+        ...(gaTrackingID && {
+          gtag: {
+            trackingID: gaTrackingID,
+            anonymizeIP: true,
+          },
+        }),
         blog: {
           showReadingTime: true,
           feedOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,10 +2276,15 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@node-rs/jieba-darwin-arm64@2.0.1":
+"@node-rs/jieba-linux-x64-gnu@2.0.1":
   version "2.0.1"
-  resolved "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-2.0.1.tgz"
-  integrity sha512-10+nwGQ6KzXXJlIL/sELA6Fi6m7eJ7xJksBiKuw1kxKUgaJwtVfAG0iqRF+NRQv0Sdq7r3k5ew9K9y0+IYaEcA==
+  resolved "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-2.0.1.tgz"
+  integrity sha512-sq3J6L2ANTE25I9eVFq/nb57OtXcvUIeUD1CTKJxwgTKIVmcB2LyOZpWf20AjHRUfbMER9Klqg5dgyyO+Six+w==
+
+"@node-rs/jieba-linux-x64-musl@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-2.0.1.tgz"
+  integrity sha512-0zfP9Qy68yEXrhBFknfhF6WUJDPU/8eRuyIrkMGdMjfRpxhpSbr2fMfnsqhOQLvhuK4w3iDFvTy4t5d0s6JKMA==
 
 "@node-rs/jieba@^2.0.1":
   version "2.0.1"
@@ -2322,10 +2327,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@parcel/watcher-darwin-arm64@2.5.1":
+"@parcel/watcher-linux-x64-glibc@2.5.1":
   version "2.5.1"
-  resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz"
-  integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.1"
@@ -7515,8 +7525,7 @@ pkg-up@^3.1.0:
 
 plugin-image-zoom@flexanalytics/plugin-image-zoom:
   version "1.1.0"
-  resolved "https://codeload.github.com/flexanalytics/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
-  integrity sha512-y/KQYx2qGrnMwB0zPxxN3g2teitLlHjGFJDoepfjJg2cC1AB5qCC9Bzp5YsNGQb2+Vw0Nd4O32b8FQGTgFSrVw==
+  resolved "git+ssh://git@github.com/flexanalytics/plugin-image-zoom.git#8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
     medium-zoom "^1.0.8"
 


### PR DESCRIPTION
## Summary

This PR removes the hardcoded Google Analytics tracking ID from `docusaurus.config.js` and loads it from the `GA_TRACKING_ID` environment variable instead.

## Changes

- Replaced the hardcoded `trackingID` value with `process.env.GA_TRACKING_ID`
- Added `GA_TRACKING_ID` to the Docusaurus build workflow using GitHub Secrets
- Added `.env` to `.gitignore` so local environment files are not committed

## Testing

Ran the Docusaurus production build locally with a test tracking ID:

## Issue Link 
https://github.com/kmesh-net/website/issues/252


```bash
GA_TRACKING_ID=G-TEST123 npm run build
