### PR TITLE
docs: fix typo in community meeting frequency

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -26,7 +26,7 @@ The community's goal is to build a high-performance service governance framework
 
 We host regular community meetings where contributors, maintainers, and users can share updates, discuss ideas, and collaborate on ongoing work.
 
-- **Frequency:** Every 2 weeks on **Thursday**
+- **Frequency:** Every week on **Thursday**
 - **Time:** 16:00 China / 08:00 UTC / 13:30 India Standard Time [Convert to your timezone](https://dateful.com/time-zone-converter?t=14%3A30&tz=GMT%2B8&)
 - **Meeting Link:** [Joining Link](https://zoom-lfx.platform.linuxfoundation.org/meeting/99299011908?password=f4c31ddd-11ed-42ae-a617-3e0842c39c58)
 - **Meeting Notes & Agenda:** [Google Docs](https://docs.google.com/document/d/1fFqolwWMVMk92yXPHvWGrMgsrb8Xru_v4Cve5ummjbk/edit?tab=t.0#heading=h.o8pz6aqnzzgk)


### PR DESCRIPTION
Description
Updated the community meeting frequency from "2 week" to "every week" to correctly reflect the current schedule.

Link

Fixes #285

Ref: https://kmesh.net/docs/community/contribute/

Changes

Corrected typo in docs/community/contribute.md.