### PR TITLE
docs(build-guide): fix typo and capitalize GitHub

### DIFF
--- a/docs/developer-guide/build-guide.md
+++ b/docs/developer-guide/build-guide.md
@@ -62,7 +62,7 @@ The Kmesh needs to be compiled and built in the Linux environment with the Kmesh
 
 ### Build Kmesh from Source
 
-Clong the source code from github.
+Clone the source code from GitHub.
 
 ```sh
 git clone https://github.com/kmesh-net/kmesh.git


### PR DESCRIPTION
## Summary

Fixes a typo in `docs/developer-guide/build-guide.md`:

* `Clong` → `Clone`
* `github` → `GitHub`

Improves documentation readability and professionalism for new contributors.

#293