### PR TITLE
docs(roadmap): update roadmap table with 2025 entries

### DIFF
--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -4,28 +4,28 @@ description: ""
 sidebar_position: 2
 ---
 
-| Feature Domain                    | Feature                                | 2023.H1 | 2023.H2 | 2024.H1 | 2024.H2 |
-| --------------------------------- | -------------------------------------- | :-----: | :-----: | :-----: | :-----: |
-| **Traffic Management**            | Sidecarless mesh                       |    ✓    |         |         |         |
-|                                   | Sockmap                                |         |    ✓    |         |         |
-|                                   | Programmable governance based on eBPF  |    ✓    |         |         |         |
-|                                   | HTTP1.1 protocol                       |    ✓    |         |         |         |
-|                                   | HTTP2 protocol                         |         |         |         |    ✓    |
-|                                   | gRPC protocol                          |         |         |         |    ✓    |
-|                                   | QUIC protocol                          |         |         |         |    ✓    |
-|                                   | TCP protocol                           |         |    ✓    |         |         |
-|                                   | Retry                                  |         |         |    ✓    |         |
-|                                   | Routing                                |    ✓    |         |         |         |
-|                                   | Load balancing                         |    ✓    |         |         |         |
-|                                   | Fault injection                        |         |         |         |    ✓    |
-|                                   | Gray release                           |    ✓    |         |         |         |
-|                                   | Circuit Breaker                        |         |         |    ✓    |         |
-|                                   | Rate Limits                            |         |         |    ✓    |         |
-| **Service Security**              | SSL-based two-way authentication       |         |         |         |    ✓    |
-|                                   | L7 authorization                       |         |         |         |    ✓    |
-|                                   | Cgroup-level isolation                 |    ✓    |         |         |         |
-| **Traffic Monitoring**            | Governance indicator monitoring        |         |    ✓    |         |         |
-|                                   | End-to-end observability               |         |         |         |    ✓    |
-| **Programmable**                  | Plug-in expansion capability           |         |         |         |    ✓    |
-| **Ecosystem Collaboration**       | Data plane collaboration (Envoy, etc.) |         |    ✓    |         |         |
-| **Operating Environment Support** | Container                              |    ✓    |         |         |         |
+| Feature Domain                    | Feature                                | 2023.H1 | 2023.H2 | 2024.H1 | 2024.H2 | 2025.H1 | 2025.H2 |
+| --------------------------------- | -------------------------------------- | :-----: | :-----: | :-----: | :-----: | :-----: | :-----: |
+| **Traffic Management**            | Sidecarless mesh                       |    ✓    |         |         |         |         |         |
+|                                   | Sockmap                                |         |    ✓    |         |         |         |         |
+|                                   | Programmable governance based on eBPF  |    ✓    |         |         |         |         |         |
+|                                   | HTTP1.1 protocol                       |    ✓    |         |         |         |         |         |
+|                                   | HTTP2 protocol                         |         |         |         |    ✓    |         |         |
+|                                   | gRPC protocol                          |         |         |         |    ✓    |         |         |
+|                                   | QUIC protocol                          |         |         |         |    ✓    |         |         |
+|                                   | TCP protocol                           |         |    ✓    |         |         |         |         |
+|                                   | Retry                                  |         |         |    ✓    |         |         |         |
+|                                   | Routing                                |    ✓    |         |         |         |         |         |
+|                                   | Load balancing                         |    ✓    |         |         |         |         |         |
+|                                   | Fault injection                        |         |         |         |    ✓    |         |         |
+|                                   | Gray release                           |    ✓    |         |         |         |         |         |
+|                                   | Circuit Breaker                        |         |         |    ✓    |         |         |         |
+|                                   | Rate Limits                            |         |         |    ✓    |         |         |         |
+| **Service Security**              | SSL-based two-way authentication       |         |         |         |    ✓    |         |         |
+|                                   | L7 authorization                       |         |         |         |    ✓    |         |         |
+|                                   | Cgroup-level isolation                 |    ✓    |         |         |         |         |         |
+| **Traffic Monitoring**            | Governance indicator monitoring        |         |    ✓    |         |         |         |         |
+|                                   | End-to-end observability               |         |         |         |    ✓    |         |         |
+| **Programmable**                  | Plug-in expansion capability           |         |         |         |    ✓    |         |         |
+| **Ecosystem Collaboration**       | Data plane collaboration (Envoy, etc.) |         |    ✓    |         |         |         |         |
+| **Operating Environment Support** | Container                              |    ✓    |         |         |         |         |         |


### PR DESCRIPTION
This PR updates the roadmap table in docs/architecture/roadmap.md to reflect 2025 planning and fixes outdated timeline columns.

No structural changes were made to the table.

#294