### PR TITLE
docs: fix typo 'Clong' → 'Clone' and capitalize 'GitHub'

### DIFF
--- a/docs/developer-guide/build-guide.md
+++ b/docs/developer-guide/build-guide.md
@@ -62,7 +62,7 @@ The Kmesh needs to be compiled and built in the Linux environment with the Kmesh
 
 ### Build Kmesh from Source
 
-Clong the source code from github.
+Clone the source code from GitHub.
 
 ```sh
 git clone https://github.com/kmesh-net/kmesh.git


### PR DESCRIPTION
Fixes #293\n\nChanges:\n- Corrected typo: 'Clong' → 'Clone'\n- Capitalized 'github' → 'GitHub' in the developer build guide.\n\nPayPal for tips: @bsknap