### PR TITLE
Added roadmap entries or columns for 2025.H1/H2

### DIFF
--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -1,31 +1,33 @@
+```md
 ---
 title: Roadmap
 description: ""
 sidebar_position: 2
 ---
 
-| Feature Domain                    | Feature                                | 2023.H1 | 2023.H2 | 2024.H1 | 2024.H2 |
-| --------------------------------- | -------------------------------------- | :-----: | :-----: | :-----: | :-----: |
-| **Traffic Management**            | Sidecarless mesh                       |    ✓    |         |         |         |
-|                                   | Sockmap                                |         |    ✓    |         |         |
-|                                   | Programmable governance based on eBPF  |    ✓    |         |         |         |
-|                                   | HTTP1.1 protocol                       |    ✓    |         |         |         |
-|                                   | HTTP2 protocol                         |         |         |         |    ✓    |
-|                                   | gRPC protocol                          |         |         |         |    ✓    |
-|                                   | QUIC protocol                          |         |         |         |    ✓    |
-|                                   | TCP protocol                           |         |    ✓    |         |         |
-|                                   | Retry                                  |         |         |    ✓    |         |
-|                                   | Routing                                |    ✓    |         |         |         |
-|                                   | Load balancing                         |    ✓    |         |         |         |
-|                                   | Fault injection                        |         |         |         |    ✓    |
-|                                   | Gray release                           |    ✓    |         |         |         |
-|                                   | Circuit Breaker                        |         |         |    ✓    |         |
-|                                   | Rate Limits                            |         |         |    ✓    |         |
-| **Service Security**              | SSL-based two-way authentication       |         |         |         |    ✓    |
-|                                   | L7 authorization                       |         |         |         |    ✓    |
-|                                   | Cgroup-level isolation                 |    ✓    |         |         |         |
-| **Traffic Monitoring**            | Governance indicator monitoring        |         |    ✓    |         |         |
-|                                   | End-to-end observability               |         |         |         |    ✓    |
-| **Programmable**                  | Plug-in expansion capability           |         |         |         |    ✓    |
-| **Ecosystem Collaboration**       | Data plane collaboration (Envoy, etc.) |         |    ✓    |         |         |
-| **Operating Environment Support** | Container                              |    ✓    |         |         |         |
+| Feature Domain                    | Feature                                | 2023.H1 | 2023.H2 | 2024.H1 | 2024.H2 | 2025.H1 | 2025.H2 |
+| --------------------------------- | -------------------------------------- | :-----: | :-----: | :-----: | :-----: | :-----: | :-----: |
+| **Traffic Management**            | Sidecarless mesh                       |    ✓    |         |         |         |         |         |
+|                                   | Sockmap                                |         |    ✓    |         |         |         |         |
+|                                   | Programmable governance based on eBPF  |    ✓    |         |         |         |         |         |
+|                                   | HTTP1.1 protocol                       |    ✓    |         |         |         |         |         |
+|                                   | HTTP2 protocol                         |         |         |         |    ✓    |         |         |
+|                                   | gRPC protocol                          |         |         |         |    ✓    |         |         |
+|                                   | QUIC protocol                          |         |         |         |    ✓    |         |         |
+|                                   | TCP protocol                           |         |    ✓    |         |         |         |         |
+|                                   | Retry                                  |         |         |    ✓    |         |         |         |
+|                                   | Routing                                |    ✓    |         |         |         |         |         |
+|                                   | Load balancing                         |    ✓    |         |         |         |         |         |
+|                                   | Fault injection                        |         |         |         |    ✓    |         |         |
+|                                   | Gray release                           |    ✓    |         |         |         |         |         |
+|                                   | Circuit Breaker                        |         |         |    ✓    |         |         |         |
+|                                   | Rate Limits                            |         |         |    ✓    |         |         |         |
+| **Service Security**              | SSL-based two-way authentication       |         |         |         |    ✓    |         |         |
+|                                   | L7 authorization                       |         |         |         |    ✓    |         |         |
+|                                   | Cgroup-level isolation                 |    ✓    |         |         |         |         |         |
+| **Traffic Monitoring**            | Governance indicator monitoring        |         |    ✓    |         |         |         |         |
+|                                   | End-to-end observability               |         |         |         |    ✓    |         |         |
+| **Programmable**                  | Plug-in expansion capability           |         |         |         |    ✓    |         |         |
+| **Ecosystem Collaboration**       | Data plane collaboration (Envoy, etc.) |         |    ✓    |         |         |         |         |
+| **Operating Environment Support** | Container                              |    ✓    |         |         |         |         |         |
+```

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -1,4 +1,3 @@
-```md
 ---
 title: Roadmap
 description: ""
@@ -30,4 +29,3 @@ sidebar_position: 2
 | **Programmable**                  | Plug-in expansion capability           |         |         |         |    ✓    |         |         |
 | **Ecosystem Collaboration**       | Data plane collaboration (Envoy, etc.) |         |    ✓    |         |         |         |         |
 | **Operating Environment Support** | Container                              |    ✓    |         |         |         |         |         |
-```


### PR DESCRIPTION
Updated `docs/architecture/roadmap.md` by adding missing roadmap columns for `2025.H1` and `2025.H2`. This keeps the roadmap documentation aligned with the project's ongoing development and provides space for tracking new features and improvements introduced after 2024.
