### PR TITLE
feat: granular debug ready status

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -1,0 +1,646 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpf
+
+// #cgo pkg-config: api-v2-c
+// #include "deserialization_to_bpf_map.h"
+import "C"
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/bpf/ads"
+	"kmesh.net/kmesh/pkg/bpf/factory"
+	"kmesh.net/kmesh/pkg/bpf/restart"
+	"kmesh.net/kmesh/pkg/bpf/workload"
+	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/kube"
+	"kmesh.net/kmesh/pkg/logger"
+	"kmesh.net/kmesh/pkg/nets"
+	"kmesh.net/kmesh/pkg/version"
+)
+
+type BpfStatus struct {
+	Ready    bool              `json:"ready"`
+	Programs map[string]string `json:"programs"`
+	Maps     map[string]string `json:"maps"`
+}
+
+var (
+	log  = logger.NewLoggerScope("bpf")
+	hash = fnv.New32a()
+)
+
+type BpfLoader struct {
+	config *options.BpfConfig
+
+	obj         *ads.BpfAds
+	workloadObj *workload.BpfWorkload
+	versionMap  *ebpf.Map
+}
+
+func NewBpfLoader(config *options.BpfConfig) *BpfLoader {
+	return &BpfLoader{
+		config:     config,
+		versionMap: NewVersionMap(config),
+	}
+}
+
+func StartMda() error {
+	cmd := exec.Command("mdacore", "enable")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error(strings.Replace(string(output), "\n", " ", -1))
+		return err
+	}
+
+	log.Info(strings.Replace(string(output), "\n", " ", -1))
+	return nil
+}
+
+func (l *BpfLoader) Start() error {
+	var err error
+	if l.config.KernelNativeEnabled() {
+		if l.obj, err = ads.NewBpfAds(l.config); err != nil {
+			return err
+		}
+		if err = l.obj.Start(); err != nil {
+			return err
+		}
+	} else if l.config.DualEngineEnabled() {
+		if l.workloadObj, err = workload.NewBpfWorkload(l.config); err != nil {
+			return err
+		}
+		if err = l.workloadObj.Start(); err != nil {
+			return err
+		}
+		// TODO: set bpf prog option in kernel native node
+		l.setBpfProgOptions()
+	}
+
+	// TODO: move start mds out of bpf loader
+	if l.config.EnableMda {
+		if err = StartMda(); err != nil {
+			return err
+		}
+	}
+
+	if restart.GetStartType() == restart.Restart {
+		log.Infof("bpf load from last pinPath")
+	}
+	return nil
+}
+
+func (l *BpfLoader) IsReady() bool {
+	return l.GetBpfStatus().Ready
+}
+
+func (l *BpfLoader) GetBpfStatus() BpfStatus {
+	status := BpfStatus{
+		Ready:    true,
+		Programs: make(map[string]string),
+		Maps:     make(map[string]string),
+	}
+
+	if l == nil || l.config == nil {
+		status.Ready = false
+		return status
+	}
+
+	if l.config.KernelNativeEnabled() {
+		if l.obj == nil {
+			status.Ready = false
+			return status
+		}
+		status.Programs["sock_conn"] = formatLinkStatus(l.obj.SockConn.Link)
+		status.Programs["sock_ops"] = formatLinkStatus(l.obj.SockOps.Link)
+		if l.obj.SockConn.Link == nil || l.obj.SockOps.Link == nil {
+			status.Ready = false
+		}
+
+		status.Maps["km_listener"] = formatMapStatus(l.obj.SockConn.KmListener)
+		status.Maps["km_cluster"] = formatMapStatus(l.obj.SockConn.KmCluster)
+	} else if l.config.DualEngineEnabled() {
+		if l.workloadObj == nil {
+			status.Ready = false
+			return status
+		}
+		status.Programs["sock_conn"] = formatLinkStatus(l.workloadObj.SockConn.Link)
+		status.Programs["sock_ops"] = formatLinkStatus(l.workloadObj.SockOps.Link)
+		status.Programs["sendmsg"] = formatLinkStatus(l.workloadObj.SendMsg.Link)
+		status.Programs["cgroup_skb"] = formatLinkStatus(l.workloadObj.CgroupSkb.Link)
+		if l.workloadObj.SockConn.Link == nil ||
+			l.workloadObj.SockOps.Link == nil ||
+			l.workloadObj.SendMsg.Link == nil ||
+			l.workloadObj.CgroupSkb.Link == nil {
+			status.Ready = false
+		}
+
+		status.Maps["km_workload"] = formatMapStatus(l.workloadObj.XdpAuth.KmWorkload)
+		status.Maps["km_frontend"] = formatMapStatus(l.workloadObj.XdpAuth.KmFrontend)
+		status.Maps["km_backend"] = formatMapStatus(l.workloadObj.XdpAuth.KmBackend)
+		status.Maps["km_endpoint"] = formatMapStatus(l.workloadObj.XdpAuth.KmEndpoint)
+	} else {
+		status.Ready = false
+	}
+
+	return status
+}
+
+func formatLinkStatus(link interface{}) string {
+	if link == nil {
+		return "not attached"
+	}
+	v := reflect.ValueOf(link)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func:
+		if v.IsNil() {
+			return "not attached"
+		}
+	}
+	if !v.IsValid() {
+		return "not attached"
+	}
+	return "ok"
+}
+
+func formatMapStatus(m *ebpf.Map) string {
+	if m == nil {
+		return "not initialized"
+	}
+	return "ok"
+}
+
+func (l *BpfLoader) GetBpfKmesh() *ads.BpfAds {
+	if l == nil {
+		return nil
+	}
+	return l.obj
+}
+
+func (l *BpfLoader) GetBpfWorkload() *workload.BpfWorkload {
+	if l == nil {
+		return nil
+	}
+	return l.workloadObj
+}
+
+func StopMda() error {
+	cmd := exec.Command("mdacore", "disable")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error(strings.Replace(string(output), "\n", " ", -1))
+		return err
+	}
+
+	log.Info(strings.Replace(string(output), "\n", " ", -1))
+	return nil
+}
+
+func (l *BpfLoader) Stop() {
+	var err error
+	C.deserial_uninit()
+	if restart.GetExitType() == restart.Restart || restart.GetExitType() == restart.Update {
+		return
+	}
+
+	closeMap(l.versionMap)
+	if l.config.KernelNativeEnabled() {
+		if err = l.obj.Stop(); err != nil {
+			CleanupBpfMap()
+			log.Errorf("failed stop bpf, err: %v", err)
+			return
+		}
+	} else if l.config.DualEngineEnabled() {
+		if err = l.workloadObj.Stop(); err != nil {
+			CleanupBpfMap()
+			log.Errorf("failed stop bpf workload, err: %v", err)
+			return
+		}
+	}
+
+	if l.config.EnableMda {
+		if err = StopMda(); err != nil {
+			log.Errorf("failed disable mda when stop kmesh, err:%s", err)
+		}
+	}
+
+	CleanupBpfMap()
+}
+
+func NewVersionMap(config *options.BpfConfig) *ebpf.Map {
+	var versionPath string
+	var kmBpfPath string
+	var versionMap *ebpf.Map
+	if config.KernelNativeEnabled() {
+		versionPath = filepath.Join(config.BpfFsPath, constants.VersionPath)
+		kmBpfPath = filepath.Join(config.BpfFsPath, constants.KmKernelNativeBpfPath)
+	} else if config.DualEngineEnabled() {
+		versionPath = filepath.Join(config.BpfFsPath, constants.WorkloadVersionPath)
+		kmBpfPath = filepath.Join(config.BpfFsPath, constants.KmDualEngineBpfPath)
+	}
+
+	versionMapPinPath := filepath.Join(versionPath, "kmesh_version")
+	_, err := os.Stat(versionPath)
+	if err == nil {
+		versionMap = recoverVersionMap(versionMapPinPath)
+		if versionMap != nil {
+			restart.SetStartStatus(versionMap)
+		}
+	}
+
+	switch restart.GetStartType() {
+	case restart.Restart:
+		return versionMap
+	case restart.Update:
+		if updateVersionMap := restart.UpdateMapHandler(versionMap, versionPath, config); updateVersionMap != nil {
+			return updateVersionMap
+		}
+	default:
+	}
+
+	// Make sure the directory about to use is clean
+	err = os.RemoveAll(kmBpfPath)
+	if err != nil {
+		log.Errorf("Clean bpf maps and progs failed, err is:%v", err)
+		return nil
+	}
+
+	mapSpec := &ebpf.MapSpec{
+		Name:       "kmesh_version",
+		Type:       ebpf.Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	}
+	m, err := ebpf.NewMap(mapSpec)
+	if err != nil {
+		log.Errorf("Create kmesh_version map failed, err is %v", err)
+		return nil
+	}
+
+	if err := os.MkdirAll(versionPath,
+		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|syscall.S_IRGRP|syscall.S_IXGRP); err != nil && !os.IsExist(err) {
+		log.Errorf("mkdir failed %v", err)
+		return nil
+	}
+
+	err = m.Pin(versionMapPinPath)
+	if err != nil {
+		log.Errorf("kmesh_version pin failed: %v", err)
+		return nil
+	}
+
+	mapspecs, err := restart.LoadCompileTimeSpecs(config)
+	if err != nil {
+		log.Errorf("failed to load compile time specs: %v", err)
+		return nil
+	}
+
+	storeVersionInfo(m)
+	log.Infof("kmesh start with Normal")
+	restart.SetStartType(restart.Normal)
+	if err := restart.SnapshotSpecsbyProg(mapspecs); err != nil {
+		log.Errorf("failed to store compile time specs: %v", err)
+		return nil
+	}
+	return m
+}
+
+func storeVersionInfo(versionMap *ebpf.Map) {
+	key := uint32(0)
+	var value uint32
+	hash.Reset()
+	hash.Write([]byte(version.Get().GitVersion))
+	value = hash.Sum32()
+	if err := versionMap.Put(&key, &value); err != nil {
+		log.Errorf("Add Version Map failed, err is %v", err)
+	}
+}
+
+func recoverVersionMap(pinPath string) *ebpf.Map {
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+
+	versionMap, err := ebpf.LoadPinnedMap(pinPath, opts)
+	if err != nil {
+		log.Infof("kmesh version map load failed: %v, start normally", err)
+
+		return nil
+	}
+	log.Debugf("recoverVersionMap success")
+
+	return versionMap
+}
+
+func (l *BpfLoader) setBpfProgOptions() {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		log.Error("skip kubelet probe failed: node name empty")
+		return
+	}
+
+	clientSet, err := kube.CreateKubeClient("")
+	if err != nil {
+		log.Errorf("get kubernetest client for getting node IP error: %v", err)
+		return
+	}
+
+	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("failed to get node: %v", err)
+		return
+	}
+
+	// pass node ip and pod gateway to skip processing of kubelet access traffic.
+	nodeIP := getNodeIPAddress(node)
+	gateway := getNodePodSubGateway(node)
+
+	// Kmesh reboot updates only the nodeIP and pod sub gateway
+	if restart.GetStartType() == restart.Normal {
+		if err := l.UpdateNodeIP(nodeIP); err != nil {
+			log.Error("set NodeIP failed ", err)
+			return
+		}
+		if err := l.UpdatePodGateway(gateway); err != nil {
+			log.Error("set PodGateway failed ", err)
+			return
+		}
+		if err := l.UpdateAuthzOffload(constants.ENABLED); err != nil {
+			log.Error("set AuthzOffload failed ", err)
+			return
+		}
+	}
+}
+
+func getNodeIPAddress(node *corev1.Node) [16]byte {
+	var nodeIPStr string
+	nodeAddresses := node.Status.Addresses
+	for _, address := range nodeAddresses {
+		if address.Type == corev1.NodeInternalIP {
+			nodeIPStr = address.Address
+		}
+	}
+
+	nodeIP, err := netip.ParseAddr(nodeIPStr)
+	if err != nil {
+		log.Errorf("failed to parse node ip: %v", err)
+		return [16]byte{}
+	}
+
+	return nodeIP.As16()
+}
+
+func getNodePodSubGateway(node *corev1.Node) [16]byte {
+	podCIDR := node.Spec.PodCIDR
+	if podCIDR == "" {
+		return [16]byte{0}
+	}
+
+	_, subNet, err := net.ParseCIDR(podCIDR)
+	if err != nil {
+		log.Errorf("failed to resolve ip from podCIDR: %v", err)
+		return [16]byte{0}
+	}
+	podGateway := [16]byte{0}
+	nets.CopyIpByteFromSlice(&podGateway, subNet.IP.To16())
+	podGateway[15] = podGateway[15] + 1
+	return podGateway
+}
+
+func (l *BpfLoader) UpdateKmeshConfigMap(config factory.GlobalBpfConfig) error {
+	if err := l.UpdateBpfLogLevel(config.BpfLogLevel); err != nil {
+		return err
+	}
+
+	if err := l.UpdateNodeIP(config.NodeIP); err != nil {
+		return err
+	}
+
+	if err := l.UpdatePodGateway(config.PodGateway); err != nil {
+		return err
+	}
+
+	if err := l.UpdateAuthzOffload(config.AuthzOffload); err != nil {
+		return err
+	}
+
+	if err := l.UpdateEnableMonitoring(config.EnableMonitoring); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetKmeshConfigMap() factory.GlobalBpfConfig {
+	return factory.GlobalBpfConfig{
+		BpfLogLevel:      l.GetBpfLogLevel(),
+		NodeIP:           l.GetNodeIP(),
+		PodGateway:       l.GetPodGateway(),
+		AuthzOffload:     l.GetAuthzOffload(),
+		EnableMonitoring: l.GetEnableMonitoring(),
+	}
+}
+
+func (l *BpfLoader) UpdateBpfLogLevel(bpfLogLevel uint32) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockConn.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set sockcon BpfLogLevel failed %w", err)
+		}
+		if err := l.workloadObj.SockOps.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set sockops BpfLogLevel failed %w", err)
+		}
+		if err := l.workloadObj.XdpAuth.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set xdp BpfLogLevel failed %w", err)
+		}
+		if err := l.workloadObj.SendMsg.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set sendmsg BpfLogLevel failed %w", err)
+		}
+		if err := l.workloadObj.CgroupSkb.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set cgroup_skb BpfLogLevel failed %w", err)
+		}
+	} else if l.obj != nil {
+		if err := l.obj.SockConn.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set sockcon BpfLogLevel failed %w", err)
+		}
+		if err := l.obj.SockOps.BpfLogLevel.Set(bpfLogLevel); err != nil {
+			return fmt.Errorf("set sockops BpfLogLevel failed %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetBpfLogLevel() uint32 {
+	var bpfLogLevel uint32
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockConn.BpfLogLevel.Get(&bpfLogLevel); err != nil {
+			log.Errorf("get BpfLogLevel failed %v", err)
+		}
+	} else if l.obj != nil {
+		if err := l.obj.SockConn.BpfLogLevel.Get(&bpfLogLevel); err != nil {
+			log.Errorf("get BpfLogLevel failed %v", err)
+		}
+	}
+
+	return bpfLogLevel
+}
+
+func (l *BpfLoader) UpdateNodeIP(nodeIP [16]byte) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockOps.NodeIp.Set(nodeIP); err != nil {
+			return fmt.Errorf("set NodeIP failed %w", err)
+		}
+	} else if l.obj != nil {
+		return fmt.Errorf("unsupported nodeIP for kernel-native mode")
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetNodeIP() [16]byte {
+	var nodeIP [16]byte
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockOps.NodeIp.Get(&nodeIP); err != nil {
+			log.Errorf("get NodeIP failed %v", err)
+		}
+	}
+	return nodeIP
+}
+
+func (l *BpfLoader) UpdatePodGateway(podGateway [16]byte) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockOps.PodGateway.Set(podGateway); err != nil {
+			return fmt.Errorf("set PodGateway failed %w", err)
+		}
+	} else if l.obj != nil {
+		return fmt.Errorf("unsupported PodGateway for kernel-native mode")
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetPodGateway() [16]byte {
+	var podGateway [16]byte
+	if l.workloadObj != nil {
+		if err := l.workloadObj.SockOps.PodGateway.Get(&podGateway); err != nil {
+			log.Errorf("get PodGateway failed %v", err)
+		}
+	}
+	return podGateway
+}
+
+func (l *BpfLoader) UpdateAuthzOffload(authzOffload uint32) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.XdpAuth.AuthzOffload.Set(authzOffload); err != nil {
+			return fmt.Errorf("set AuthzOffload failed %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetAuthzOffload() uint32 {
+	var authzOffload uint32
+	if l.workloadObj != nil {
+		if err := l.workloadObj.XdpAuth.AuthzOffload.Get(&authzOffload); err != nil {
+			log.Errorf("get AuthzOffload failed %v", err)
+		}
+	}
+	return authzOffload
+}
+
+func (l *BpfLoader) UpdateEnableMonitoring(enableMonitoring uint32) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.CgroupSkb.EnableMonitoring.Set(enableMonitoring); err != nil {
+			return fmt.Errorf("set CgroupSkb EnableMonitoring failed %w", err)
+		}
+		if err := l.workloadObj.SockOps.EnableMonitoring.Set(enableMonitoring); err != nil {
+			return fmt.Errorf("set SockOps EnableMonitoring failed %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *BpfLoader) GetEnableMonitoring() uint32 {
+	var enableMonitoring uint32
+	if l.workloadObj != nil {
+		if err := l.workloadObj.CgroupSkb.EnableMonitoring.Get(&enableMonitoring); err != nil {
+			log.Errorf("get EnableMonitoring failed %v", err)
+		}
+	}
+	return enableMonitoring
+}
+
+func (l *BpfLoader) UpdateEnablePeriodicReport(EnablePeriodicReport uint32) error {
+	if l.workloadObj != nil {
+		if err := l.workloadObj.CgroupSkb.EnablePeriodicReport.Set(EnablePeriodicReport); err != nil {
+			return fmt.Errorf("set CgroupSkb enable periodic report failed %w", err)
+		}
+	}
+	return nil
+}
+
+func closeMap(m *ebpf.Map) {
+	if m == nil {
+		return
+	}
+
+	if err := m.Unpin(); err != nil {
+		log.Errorf("Failed to unpin kmesh_version: %v", err)
+	}
+
+	if err := m.Close(); err != nil {
+		log.Errorf("Failed to close kmesh_version: %v", err)
+	}
+
+	log.Infof("cleaned kmesh_version map")
+}
+
+func CleanupBpfMap() {
+	err := syscall.Unmount(constants.Cgroup2Path, 0)
+	if err != nil {
+		log.Errorf("unmount /mnt/kmesh_cgroup2 error: %v", err)
+	}
+	err = syscall.Unmount(constants.BpfFsPath, 0)
+	if err != nil {
+		log.Errorf("unmount /sys/fs/bpf error: %v", err)
+	}
+	err = os.RemoveAll(constants.Cgroup2Path)
+	if err != nil {
+		log.Errorf("remove /mnt/kmesh_cgroup2 error: %v", err)
+	}
+	log.Info("cleanup bpf map success")
+}

--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ads
+
+import (
+	"context"
+	"fmt"
+
+	"sync"
+	"sync/atomic"
+
+	service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"istio.io/istio/pkg/channels"
+
+	bpfads "kmesh.net/kmesh/pkg/bpf/ads"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var (
+	log = logger.NewLoggerScope("ads_controller")
+)
+
+type Controller struct {
+	Processor             *processor
+	dnsResolverController *dnsController
+	mu                    sync.RWMutex
+	con                   *connection
+	initialized           atomic.Bool
+}
+
+type connection struct {
+	Stream       service_discovery_v3.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+	requestsChan *channels.Unbounded[*service_discovery_v3.DiscoveryRequest]
+	stopCh       chan struct{}
+}
+
+func NewController(bpfAds *bpfads.BpfAds) *Controller {
+	processor := newProcessor(bpfAds)
+	// create kernel-native mode ads resolver controller
+	dnsResolverController, err := NewDnsController(processor.Cache)
+	if err != nil {
+		log.Errorf("dns resolver of Kernel-Native mode create failed: %v", err)
+		return nil
+	}
+	processor.DnsResolverChan = dnsResolverController.clustersChan
+
+	return &Controller{
+		dnsResolverController: dnsResolverController,
+		Processor:             processor,
+	}
+}
+
+func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.AggregatedDiscoveryServiceClient, ctx context.Context) error {
+	c.mu.Lock()
+	if c.con != nil {
+		close(c.con.stopCh)
+	}
+
+	stream, err := client.StreamAggregatedResources(ctx)
+	if err != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("StreamAggregatedResources failed, %s", err)
+	}
+
+	c.con = &connection{
+		Stream:       stream,
+		requestsChan: channels.NewUnbounded[*service_discovery_v3.DiscoveryRequest](),
+		stopCh:       make(chan struct{}),
+	}
+	con := c.con
+	c.mu.Unlock()
+
+	c.Processor.Reset()
+	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
+		return fmt.Errorf("send request failed, %s", err)
+	}
+	go sendUpstream(con)
+
+	return nil
+}
+
+func (c *Controller) HandleAdsStream() error {
+	var (
+		err error
+		rsp *service_discovery_v3.DiscoveryResponse
+	)
+
+	c.mu.RLock()
+	con := c.con
+	c.mu.RUnlock()
+	if con == nil {
+		return fmt.Errorf("connection is nil")
+	}
+
+	if rsp, err = con.Stream.Recv(); err != nil {
+		_ = con.Stream.CloseSend()
+		return fmt.Errorf("stream recv failed, %s", err)
+	}
+
+	// Because Kernel-Native mode is full update.
+	// So the original clusterCache is deleted when a new resp is received.
+	c.dnsResolverController.newClusterCache()
+	c.Processor.processAdsResponse(rsp)
+	c.initialized.Store(true)
+	con.requestsChan.Put(c.Processor.ack)
+	if c.Processor.req != nil {
+		con.requestsChan.Put(c.Processor.req)
+		c.Processor.req = nil
+	}
+
+	return nil
+}
+
+func sendUpstream(con *connection) {
+	for {
+		select {
+		case req := <-con.requestsChan.Get():
+			con.requestsChan.Load()
+			if err := con.Stream.Send(req); err != nil {
+				log.Errorf("send error for type url %s: %v", req.TypeUrl, err)
+				return
+			}
+		case <-con.stopCh:
+			return
+		}
+	}
+}
+
+func (c *Controller) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.con != nil {
+		close(c.con.stopCh)
+		_ = c.con.Stream.CloseSend()
+	}
+}
+
+func (c *Controller) IsReady() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.con != nil && c.con.Stream != nil && c.initialized.Load()
+}
+
+func (c *Controller) StartDnsController(stopCh <-chan struct{}) {
+	if c.dnsResolverController != nil {
+		c.dnsResolverController.Run(stopCh)
+	}
+}

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -1,0 +1,262 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
+	istioGrpc "istio.io/istio/pilot/pkg/grpc"
+
+	bpfads "kmesh.net/kmesh/pkg/bpf/ads"
+	bpfwl "kmesh.net/kmesh/pkg/bpf/workload"
+	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/controller/ads"
+	"kmesh.net/kmesh/pkg/controller/config"
+	"kmesh.net/kmesh/pkg/controller/workload"
+	"kmesh.net/kmesh/pkg/nets"
+)
+
+const (
+	RandTimeSed = 1000
+)
+
+type XdsClient struct {
+	mode               string
+	ctx                context.Context
+	cancel             context.CancelFunc
+	mu                 sync.RWMutex
+	grpcConn           *grpc.ClientConn
+	client             discoveryv3.AggregatedDiscoveryServiceClient
+	AdsController      *ads.Controller
+	WorkloadController *workload.Controller
+	xdsConfig          *config.XdsConfig
+	reconnectCount     uint64
+	lastConnect        time.Time
+}
+
+func NewXdsClient(mode string, bpfAds *bpfads.BpfAds, bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enableProfiling bool) (*XdsClient, error) {
+	client := &XdsClient{
+		mode:      mode,
+		xdsConfig: config.GetConfig(mode),
+	}
+
+	switch mode {
+	case constants.DualEngineMode:
+		var err error
+		client.WorkloadController, err = workload.NewController(bpfWorkload, enableMonitoring, enableProfiling)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create workload controller: %w", err)
+		}
+	case constants.KernelNativeMode:
+		client.AdsController = ads.NewController(bpfAds)
+	}
+
+	client.ctx, client.cancel = context.WithCancel(context.Background())
+	client.ctx = metadata.AppendToOutgoingContext(client.ctx, "ClusterID", client.xdsConfig.Metadata.ClusterID.String())
+	return client, nil
+}
+
+func (c *XdsClient) createGrpcStreamClient() error {
+	var err error
+
+	c.mu.Lock()
+	if c.grpcConn, err = nets.GrpcConnect(c.xdsConfig.DiscoveryAddress); err != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("grpc connect failed: %s", err)
+	}
+
+	c.client = discoveryv3.NewAggregatedDiscoveryServiceClient(c.grpcConn)
+	c.lastConnect = time.Now()
+	c.mu.Unlock()
+
+	if c.mode == constants.DualEngineMode {
+		if err = c.WorkloadController.WorkloadStreamCreateAndSend(c.client, c.ctx); err != nil {
+			_ = c.grpcConn.Close()
+			return fmt.Errorf("create workload stream failed, %s", err)
+		}
+	} else if c.mode == constants.KernelNativeMode {
+		if err = c.AdsController.AdsStreamCreateAndSend(c.client, c.ctx); err != nil {
+			_ = c.grpcConn.Close()
+			return fmt.Errorf("create ads stream failed, %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *XdsClient) recoverConnection() {
+	var (
+		err      error
+		interval = time.Second
+	)
+
+	for {
+		if err = c.createGrpcStreamClient(); err == nil {
+			log.Infof("grpc reconnect succeed")
+			return
+		}
+
+		c.mu.Lock()
+		c.reconnectCount++
+		c.mu.Unlock()
+
+		log.Errorf("grpc reconnect failed, %s", err)
+		time.Sleep(interval + nets.CalculateRandTime(RandTimeSed))
+		interval = nets.CalculateInterval(interval)
+	}
+}
+
+func (c *XdsClient) handleUpstream(ctx context.Context) {
+	var (
+		err       error
+		reconnect = false
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if reconnect {
+				c.recoverConnection()
+				reconnect = false
+			}
+
+			if c.mode == constants.KernelNativeMode {
+				err = c.AdsController.HandleAdsStream()
+			} else if c.mode == constants.DualEngineMode {
+				err = c.WorkloadController.HandleWorkloadStream()
+			}
+			if err != nil {
+				if istioGrpc.GRPCErrorType(err) == istioGrpc.UnexpectedError {
+					log.Errorf("Failed to establish grpc link to control plane: %v", err)
+				}
+				c.mu.Lock()
+				if c.grpcConn != nil {
+					_ = c.grpcConn.Close()
+				}
+				c.mu.Unlock()
+				reconnect = true
+			}
+		}
+	}
+}
+
+func (c *XdsClient) Run(stopCh <-chan struct{}) error {
+	if err := c.createGrpcStreamClient(); err != nil {
+		return fmt.Errorf("create client and stream failed, %s", err)
+	}
+
+	go c.handleUpstream(c.ctx)
+
+	go func() {
+		<-stopCh
+		c.closeStreamClient()
+		if c.cancel != nil {
+			c.cancel()
+		}
+	}()
+
+	return nil
+}
+
+func (c *XdsClient) closeStreamClient() {
+	if c.AdsController != nil {
+		c.AdsController.Close()
+	}
+	if c.WorkloadController != nil && c.WorkloadController.Stream != nil {
+		_ = c.WorkloadController.Stream.CloseSend()
+	}
+
+	c.mu.Lock()
+	if c.grpcConn != nil {
+		_ = c.grpcConn.Close()
+	}
+	c.mu.Unlock()
+}
+
+func (c *XdsClient) Close() error {
+	return nil
+}
+
+func (c *XdsClient) IsReady() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.grpcConn == nil {
+		return false
+	}
+	if c.grpcConn.GetState() != connectivity.Ready {
+		return false
+	}
+	if c.AdsController != nil {
+		return c.AdsController.IsReady()
+	}
+	if c.WorkloadController != nil {
+		return c.WorkloadController.IsReady()
+	}
+	return false
+}
+
+func (c *XdsClient) GetGrpcState() string {
+	if c == nil {
+		return connectivity.Shutdown.String()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.grpcConn == nil {
+		return connectivity.Shutdown.String()
+	}
+	return c.grpcConn.GetState().String()
+}
+
+func (c *XdsClient) GetControllerStatus() string {
+	if c == nil {
+		return "not initialized"
+	}
+	if c.AdsController != nil {
+		if c.AdsController.IsReady() {
+			return "ok"
+		}
+		return "not ready"
+	}
+	if c.WorkloadController != nil {
+		if c.WorkloadController.IsReady() {
+			return "ok"
+		}
+		return "not ready"
+	}
+	return "not initialized"
+}
+
+func (c *XdsClient) GetXdsStreamStability() string {
+	if c == nil {
+		return "not initialized"
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return fmt.Sprintf("reconnects: %d, last_connect: %v", c.reconnectCount, c.lastConnect.Format(time.RFC3339))
+}

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -1,0 +1,238 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workload
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
+	"kmesh.net/kmesh/pkg/auth"
+	"kmesh.net/kmesh/pkg/bpf/restart"
+	bpfwl "kmesh.net/kmesh/pkg/bpf/workload"
+	"kmesh.net/kmesh/pkg/controller/telemetry"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+const (
+	AddressType       = "type.googleapis.com/istio.workload.Address"
+	AuthorizationType = "type.googleapis.com/istio.security.Authorization"
+)
+
+var log = logger.NewLoggerScope("workload_controller")
+
+type Controller struct {
+	mu                        sync.RWMutex
+	Stream                    discoveryv3.AggregatedDiscoveryService_DeltaAggregatedResourcesClient
+	Processor                 *Processor
+	Rbac                      *auth.Rbac
+	MetricController          *telemetry.MetricController
+	MapMetricController       *telemetry.MapMetricController
+	OperationMetricController *telemetry.BpfProgMetric
+	bpfWorkloadObj            *bpfwl.BpfWorkload
+	dnsResolverController     *dnsController
+	initialized               atomic.Bool
+}
+
+func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfMonitor bool) (*Controller, error) {
+	processor := NewProcessor(bpfWorkload.SockConn.KmeshCgroupSockWorkloadObjects.KmeshCgroupSockWorkloadMaps)
+	dnsResolverController, err := NewDnsController(processor.WorkloadCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DNS resolver for Dual-Engine mode: %w", err)
+	}
+	processor.DnsResolverChan = dnsResolverController.workloadsChan
+	processor.ResolvedDomainChanMap = dnsResolverController.ResolvedDomainChanMap
+
+	// Set up callback to clean DNS cache when workload is deleted
+	processor.onWorkloadDeleted = func(workloadName string) {
+		dnsResolverController.removeWorkloadFromDnsCache(workloadName)
+	}
+
+	c := &Controller{
+		Processor:             processor,
+		bpfWorkloadObj:        bpfWorkload,
+		dnsResolverController: dnsResolverController,
+	}
+	// do some initialization when restart
+	// restore endpoint index, otherwise endpoint number can double
+	if restart.GetStartType() == restart.Restart {
+		c.Processor.bpf.RestoreEndpointKeys()
+	}
+	c.Rbac = auth.NewRbac(c.Processor.WorkloadCache)
+	c.MetricController = telemetry.NewMetric(c.Processor.WorkloadCache, c.Processor.ServiceCache, enableMonitoring)
+	if enablePerfMonitor {
+		c.OperationMetricController = telemetry.NewBpfProgMetric()
+		c.MapMetricController = telemetry.NewMapMetric()
+	}
+	return c, nil
+}
+
+func (c *Controller) Run(ctx context.Context, stopCh <-chan struct{}) error {
+	if err := c.Processor.PrepareDNSProxy(); err != nil {
+		log.Errorf("failed to prepare for dns proxy, err: %+v", err)
+		return err
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		<-c.Processor.addressDone
+		wg.Done()
+	}()
+	go func() {
+		<-c.Processor.authzDone
+		wg.Done()
+	}()
+	go func() {
+		wg.Wait()
+		c.Rbac.Run(ctx, c.bpfWorkloadObj.SockOps.KmAuthReq, c.bpfWorkloadObj.XdpAuth.KmAuthRes)
+	}()
+
+	go c.MetricController.Run(ctx, c.bpfWorkloadObj.SockConn.KmTcpProbe)
+	if c.MapMetricController != nil {
+		go c.MapMetricController.Run(ctx)
+	}
+	if c.OperationMetricController != nil {
+		go c.OperationMetricController.Run(ctx, c.bpfWorkloadObj.SockConn.KmPerfInfo)
+	}
+	if c.dnsResolverController != nil {
+		go c.dnsResolverController.Run(stopCh)
+	}
+	return nil
+}
+
+func (c *Controller) Close() error {
+	return c.Processor.Close()
+}
+
+func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDiscoveryServiceClient, ctx context.Context) error {
+	var (
+		err                     error
+		initialResourceVersions map[string]string
+	)
+
+	c.mu.Lock()
+	c.Stream, err = client.DeltaAggregatedResources(ctx)
+	if err != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("DeltaAggregatedResources failed, %s", err)
+	}
+	stream := c.Stream
+	c.mu.Unlock()
+
+	if c.Processor != nil {
+		cachedServices := c.Processor.ServiceCache.List()
+		cachedWorkloads := c.Processor.WorkloadCache.List()
+		initialResourceVersions = make(map[string]string, len(cachedServices)+len(cachedWorkloads))
+
+		// add cached resource names
+		for _, service := range cachedServices {
+			initialResourceVersions[service.ResourceName()] = ""
+		}
+
+		for _, workload := range cachedWorkloads {
+			initialResourceVersions[workload.ResourceName()] = ""
+		}
+	}
+
+	log.Debugf("send initial request with address resources: %v", initialResourceVersions)
+	if err := stream.Send(newDeltaRequest(AddressType, nil, initialResourceVersions)); err != nil {
+		return fmt.Errorf("send request failed, %s", err)
+	}
+
+	initialResourceVersions = c.Rbac.GetAllPolicies()
+	log.Debugf("send initial request with authorization resources: %v", initialResourceVersions)
+	if err = stream.Send(newDeltaRequest(AuthorizationType, nil, initialResourceVersions)); err != nil {
+		return fmt.Errorf("authorization subscribe failed, %s", err)
+	}
+
+	return nil
+}
+
+func (c *Controller) HandleWorkloadStream() error {
+	var (
+		err      error
+		rspDelta *discoveryv3.DeltaDiscoveryResponse
+	)
+
+	c.mu.RLock()
+	stream := c.Stream
+	c.mu.RUnlock()
+	if stream == nil {
+		return fmt.Errorf("stream is nil")
+	}
+
+	if rspDelta, err = stream.Recv(); err != nil {
+		_ = stream.CloseSend()
+		return fmt.Errorf("stream recv failed, %s", err)
+	}
+
+	c.Processor.processWorkloadResponse(rspDelta, c.Rbac)
+	c.initialized.Store(true)
+
+	if err = stream.Send(c.Processor.ack); err != nil {
+		return fmt.Errorf("stream send ack failed, %s", err)
+	}
+
+	if c.Processor.req != nil {
+		if err = stream.Send(c.Processor.req); err != nil {
+			return fmt.Errorf("stream send req failed, %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) SetMonitoringTrigger(enabled bool) {
+	c.MetricController.EnableMonitoring.Store(enabled)
+}
+
+func (c *Controller) GetMonitoringTrigger() bool {
+	return c.MetricController.EnableMonitoring.Load()
+}
+
+func (c *Controller) SetAccesslogTrigger(enabled bool) {
+	c.MetricController.EnableAccesslog.Store(enabled)
+}
+
+func (c *Controller) GetAccesslogTrigger() bool {
+	return c.MetricController.EnableAccesslog.Load()
+}
+
+func (c *Controller) SetWorkloadMetricTrigger(enable bool) {
+	c.MetricController.EnableWorkloadMetric.Store(enable)
+}
+
+func (c *Controller) GetWorklaodMetricTrigger() bool {
+	return c.MetricController.EnableWorkloadMetric.Load()
+}
+
+func (c *Controller) SetConnectionMetricTrigger(enable bool) {
+	c.MetricController.EnableConnectionMetric.Store(enable)
+}
+
+func (c *Controller) GetConnectionMetricTrigger() bool {
+	return c.MetricController.EnableConnectionMetric.Load()
+}
+
+func (c *Controller) IsReady() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Stream != nil && c.initialized.Load()
+}

--- a/pkg/status/ready_test.go
+++ b/pkg/status/ready_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package status
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServer_readyProbe(t *testing.T) {
+	t.Run("nil loader and nil xdsClient returns not ready", func(t *testing.T) {
+		server := &Server{}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var resp ReadyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Nil(t, err)
+		assert.False(t, resp.Ready)
+		assert.Equal(t, "not initialized", resp.Components["bpf"])
+		assert.Equal(t, "not initialized", resp.Components["xds_connection"])
+		assert.Equal(t, "not initialized", resp.Components["controller"])
+		assert.Equal(t, uint64(0), resp.Xds.ReconnectCount)
+	})
+}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -1,0 +1,654 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package status
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/pprof"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	adminv2 "kmesh.net/kmesh/api/v2/admin"
+	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/bpf"
+	bpfads "kmesh.net/kmesh/pkg/bpf/ads"
+	maps_v2 "kmesh.net/kmesh/pkg/cache/v2/maps"
+	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/controller"
+	"kmesh.net/kmesh/pkg/controller/ads"
+	"kmesh.net/kmesh/pkg/logger"
+	"kmesh.net/kmesh/pkg/version"
+)
+
+var log = logger.NewLoggerScope("status")
+
+const (
+	adminAddr = "localhost:15200"
+
+	patternVersion            = "/version"
+	patternBpfAdsMaps         = "/debug/config_dump/bpf/kernel-native"
+	patternBpfWorkloadMaps    = "/debug/config_dump/bpf/dual-engine"
+	configDumpPrefix          = "/debug/config_dump"
+	patternConfigDumpAds      = configDumpPrefix + "/kernel-native"
+	patternConfigDumpWorkload = configDumpPrefix + "/dual-engine"
+	patternReadyProbe         = "/debug/ready"
+	patternLoggers            = "/debug/loggers"
+	patternAccesslog          = "/accesslog"
+	patternMonitoring         = "/monitoring"
+	patternWorkloadMetrics    = "/workload_metrics"
+	patternConnectionMetrics  = "/connection_metrics"
+	patternAuthz              = "/authz"
+
+	bpfLoggerName = "bpf"
+
+	httpTimeout = time.Second * 20
+
+	invalidModeErrMessage = "\tInvalid Client Mode\n"
+)
+
+type Server struct {
+	config    *options.BootstrapConfigs
+	xdsClient *controller.XdsClient
+	mux       *http.ServeMux
+	server    *http.Server
+	loader    *bpf.BpfLoader
+}
+
+func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loader *bpf.BpfLoader) *Server {
+	s := &Server{
+		config:    configs,
+		xdsClient: c,
+		mux:       http.NewServeMux(),
+		loader:    loader,
+	}
+	s.server = &http.Server{
+		Addr:         adminAddr,
+		Handler:      s.mux,
+		ReadTimeout:  httpTimeout,
+		WriteTimeout: httpTimeout,
+	}
+
+	s.mux.HandleFunc(patternVersion, s.version)
+	s.mux.HandleFunc(patternBpfAdsMaps, s.bpfAdsMaps)
+	s.mux.HandleFunc(patternBpfWorkloadMaps, s.bpfWorkloadMaps)
+	s.mux.HandleFunc(patternConfigDumpAds, s.configDumpAds)
+	s.mux.HandleFunc(patternConfigDumpWorkload, s.configDumpWorkload)
+	s.mux.HandleFunc(patternLoggers, s.loggersHandler)
+	s.mux.HandleFunc(patternAccesslog, s.accesslogHandler)
+	s.mux.HandleFunc(patternMonitoring, s.monitoringHandler)
+	s.mux.HandleFunc(patternWorkloadMetrics, s.workloadMetricHandler)
+	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
+	s.mux.HandleFunc(patternAuthz, s.authzHandler)
+
+	// TODO: add dump certificate, authorizationPolicies and services
+	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
+
+	// support pprof
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return s
+}
+
+func (s *Server) version(w http.ResponseWriter, r *http.Request) {
+	v := version.Get()
+
+	data, err := json.MarshalIndent(&v, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal version info: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) checkWorkloadMode(w http.ResponseWriter) bool {
+	client := s.xdsClient
+	if client == nil || client.WorkloadController == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, invalidModeErrMessage)
+		return false
+	}
+	return true
+}
+
+func (s *Server) checkAdsMode(w http.ResponseWriter) bool {
+	client := s.xdsClient
+	if client == nil || client.AdsController == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, invalidModeErrMessage)
+		return false
+	}
+	return true
+}
+
+func (s *Server) bpfWorkloadMaps(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	client := s.xdsClient
+	bpfMaps := client.WorkloadController.Processor.GetBpfCache()
+	workloadBpfDump := NewWorkloadBpfDump(s.xdsClient.WorkloadController.Processor.GetHashName()).
+		WithBackends(bpfMaps.BackendLookupAll()).
+		WithEndpoints(bpfMaps.EndpointLookupAll()).
+		WithFrontends(bpfMaps.FrontendLookupAll()).
+		WithServices(bpfMaps.ServiceLookupAll()).
+		WithWorkloadPolicies(bpfMaps.WorkloadPolicyLookupAll())
+
+	printWorkloadBpfDump(w, workloadBpfDump)
+}
+
+func printWorkloadBpfDump(w http.ResponseWriter, wbd WorkloadBpfDump) {
+	data, err := json.MarshalIndent(wbd, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal WorkloadBpfDump: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) bpfAdsMaps(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAdsMode(w) {
+		return
+	}
+	var err error
+	dynamicRes := &adminv2.ConfigResources{}
+	dynamicRes.ClusterConfigs, err = maps_v2.ClusterLookupAll()
+	if err != nil {
+		log.Errorf("ClusterLookupAll failed: %v", err)
+	}
+	dynamicRes.ListenerConfigs, err = maps_v2.ListenerLookupAll()
+	if err != nil {
+		log.Errorf("ListenerLookupAll failed: %v", err)
+	}
+	if bpfads.AdsL7Enabled() {
+		dynamicRes.RouteConfigs, err = maps_v2.RouteConfigLookupAll()
+		if err != nil {
+			log.Errorf("RouteConfigLookupAll failed: %v", err)
+		}
+	}
+	ads.SetApiVersionInfo(dynamicRes)
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, protojson.Format(&adminv2.ConfigDump{
+		DynamicResources: dynamicRes,
+	}))
+}
+
+type LoggerInfo struct {
+	Name  string `json:"name,omitempty"`
+	Level string `json:"level,omitempty"`
+}
+
+func (s *Server) loggersHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		s.getLoggerLevel(w, r)
+	} else if r.Method == http.MethodPost {
+		s.setLoggerLevel(w, r)
+	} else {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) accesslogHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	accesslogInfo := r.URL.Query().Get("enable")
+	enabled, err := strconv.ParseBool(accesslogInfo)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", accesslogInfo)))
+		return
+	}
+
+	if s.loader.GetEnableMonitoring() == constants.DISABLED && enabled {
+		http.Error(w, "Kmesh monitoring is disabled, cannot enable accesslog.", http.StatusBadRequest)
+		return
+	}
+
+	s.xdsClient.WorkloadController.SetAccesslogTrigger(enabled)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) monitoringHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	info := r.URL.Query().Get("enable")
+	enabled, err := strconv.ParseBool(info)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid monitoring enable=%s", info)))
+		return
+	}
+	enableMonitoring := constants.DISABLED
+	if enabled {
+		enableMonitoring = constants.ENABLED
+	}
+	if err := s.loader.UpdateEnableMonitoring(enableMonitoring); err != nil {
+		http.Error(w, fmt.Sprintf("update bpf monitoring failed: %v", err), http.StatusBadRequest)
+		return
+	}
+	if err := s.loader.UpdateEnablePeriodicReport(enableMonitoring); err != nil {
+		http.Error(w, fmt.Sprintf("update enable periodic report failed: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	s.xdsClient.WorkloadController.SetMonitoringTrigger(enabled)
+	s.xdsClient.WorkloadController.SetAccesslogTrigger(enabled)
+	s.xdsClient.WorkloadController.SetWorkloadMetricTrigger(enabled)
+	s.xdsClient.WorkloadController.SetConnectionMetricTrigger(enabled)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) workloadMetricHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	info := r.URL.Query().Get("enable")
+	enabled, err := strconv.ParseBool(info)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		return
+	}
+
+	if s.loader.GetEnableMonitoring() == constants.DISABLED && enabled {
+		http.Error(w, "Kmesh monitoring is disabled, cannot enable workload metrics.", http.StatusBadRequest)
+		return
+	}
+
+	s.xdsClient.WorkloadController.SetWorkloadMetricTrigger(enabled)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	info := r.URL.Query().Get("enable")
+	enabled, err := strconv.ParseBool(info)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		return
+	}
+
+	if s.loader.GetEnableMonitoring() == constants.DISABLED && enabled {
+		http.Error(w, "Kmesh monitoring is disabled, cannot enable connection metrics.", http.StatusBadRequest)
+		return
+	}
+
+	enablePeriodicReport := constants.DISABLED
+	if enabled {
+		enablePeriodicReport = constants.ENABLED
+	}
+	if err := s.loader.UpdateEnablePeriodicReport(enablePeriodicReport); err != nil {
+		http.Error(w, fmt.Sprintf("update enable periodic report failed: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	s.xdsClient.WorkloadController.SetConnectionMetricTrigger(enabled)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	authzInfo := r.URL.Query().Get("enable")
+	enabled, err := strconv.ParseBool(authzInfo)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid authz enable=%s", authzInfo)))
+		return
+	}
+	var authzOffload uint32
+	if enabled {
+		authzOffload = constants.ENABLED
+	} else {
+		authzOffload = constants.DISABLED
+	}
+	if err := s.loader.UpdateAuthzOffload(authzOffload); err != nil {
+		http.Error(w, fmt.Sprintf("update bpf authz failed: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) getLoggerNames(w http.ResponseWriter) {
+	loggerNames := append(logger.GetLoggerNames(), bpfLoggerName)
+	data, err := json.MarshalIndent(&loggerNames, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal logger names: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(data)
+}
+
+func (s *Server) getLoggerLevel(w http.ResponseWriter, r *http.Request) {
+	loggerName := r.URL.Query().Get("name")
+	if loggerName == "" {
+		s.getLoggerNames(w)
+		return
+	}
+	var loggerInfo *LoggerInfo
+	if loggerName != bpfLoggerName {
+		loggerLevel, err := logger.GetLoggerLevel(loggerName)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "\t%v\n", err)
+			return
+		}
+		loggerInfo = &LoggerInfo{
+			Name:  loggerName,
+			Level: loggerLevel.String(),
+		}
+	} else {
+		var err error
+		loggerInfo, err = s.getBpfLogLevel()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	data, err := json.MarshalIndent(&loggerInfo, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal logger info: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) setLoggerLevel(w http.ResponseWriter, r *http.Request) {
+	var (
+		loggerInfo  LoggerInfo
+		loggerLevel logrus.Level
+	)
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "\t%s: %v\n", "Error reading request body", err)
+		return
+	}
+
+	if err = json.Unmarshal(body, &loggerInfo); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "\t%s: %v\n", "Invalid request body format", err)
+		return
+	}
+
+	if loggerInfo.Name == bpfLoggerName {
+		s.setBpfLogLevel(w, loggerInfo.Level)
+		return
+	}
+
+	if loggerLevel, err = logrus.ParseLevel(loggerInfo.Level); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "\t%s: %v\n", "Invalid request body format", err)
+		return
+	}
+
+	if err = logger.SetLoggerLevel(loggerInfo.Name, loggerLevel); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "\t%v\n", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+}
+
+func (s *Server) configDumpAds(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAdsMode(w) {
+		return
+	}
+
+	client := s.xdsClient
+	w.WriteHeader(http.StatusOK)
+	cache := client.AdsController.Processor.Cache
+	dynamicRes := &adminv2.ConfigResources{}
+
+	dynamicRes.ClusterConfigs = cache.ClusterCache.Dump()
+	dynamicRes.ListenerConfigs = cache.ListenerCache.Dump()
+	dynamicRes.RouteConfigs = cache.RouteCache.Dump()
+	ads.SetApiVersionInfo(dynamicRes)
+
+	fmt.Fprintln(w, protojson.Format(&adminv2.ConfigDump{
+		DynamicResources: dynamicRes,
+	}))
+}
+
+type WorkloadDump struct {
+	Workloads []*Workload            `json:"workloads"`
+	Services  []*Service             `json:"services"`
+	Policies  []*AuthorizationPolicy `json:"policies"`
+}
+
+func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+
+	client := s.xdsClient
+
+	workloads := client.WorkloadController.Processor.WorkloadCache.List()
+	services := client.WorkloadController.Processor.ServiceCache.List()
+	policies := client.WorkloadController.Rbac.PoliciesList()
+	workloadDump := WorkloadDump{
+		Workloads: make([]*Workload, 0, len(workloads)),
+		Services:  make([]*Service, 0, len(services)),
+		Policies:  make([]*AuthorizationPolicy, 0, len(policies)),
+	}
+	for _, w := range workloads {
+		workloadDump.Workloads = append(workloadDump.Workloads, ConvertWorkload(w))
+	}
+	for _, s := range services {
+		workloadDump.Services = append(workloadDump.Services, ConvertService(s))
+	}
+	for _, p := range policies {
+		workloadDump.Policies = append(workloadDump.Policies, ConvertAuthorizationPolicy(p))
+	}
+	printWorkloadDump(w, workloadDump)
+}
+
+type ReadyResponse struct {
+	Ready      bool              `json:"ready"`
+	Components map[string]string `json:"components"`
+	Bpf        bpf.BpfStatus     `json:"bpf_status"`
+	Xds        XdsStatus         `json:"xds_status"`
+}
+
+type XdsStatus struct {
+	State           string    `json:"state"`
+	Controller      string    `json:"controller"`
+	ReconnectCount  uint64    `json:"reconnect_count"`
+	LastConnectTime time.Time `json:"last_connect_time"`
+}
+
+func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
+	ready := true
+	components := make(map[string]string)
+
+	var bpfStatus bpf.BpfStatus
+	if s.loader != nil {
+		bpfStatus = s.loader.GetBpfStatus()
+		if bpfStatus.Ready {
+			components["bpf"] = "ok"
+		} else {
+			components["bpf"] = "not ready"
+			ready = false
+		}
+	} else {
+		components["bpf"] = "not initialized"
+		ready = false
+	}
+
+	var xdsStatus XdsStatus
+	if s.xdsClient != nil {
+		reconnectCount, lastConnectTime := s.xdsClient.GetXdsStreamStability()
+		xdsStatus = XdsStatus{
+			State:           s.xdsClient.GetGrpcState(),
+			Controller:      s.xdsClient.GetControllerStatus(),
+			ReconnectCount:  reconnectCount,
+			LastConnectTime: lastConnectTime,
+		}
+		components["xds_connection"] = xdsStatus.State
+		components["controller"] = xdsStatus.Controller
+		if !s.xdsClient.IsReady() {
+			ready = false
+		}
+	} else {
+		components["xds_connection"] = "not initialized"
+		components["controller"] = "not initialized"
+		ready = false
+	}
+
+	resp := ReadyResponse{
+		Ready:      ready,
+		Components: components,
+		Bpf:        bpfStatus,
+		Xds:        xdsStatus,
+	}
+
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		log.Errorf("failed to marshal ready response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if !ready {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	_, _ = w.Write(data)
+}
+
+func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {
+	logLevel := s.loader.GetBpfLogLevel()
+	logLevelMap := map[int]string{
+		constants.BPF_LOG_ERR:   "error",
+		constants.BPF_LOG_WARN:  "warn",
+		constants.BPF_LOG_INFO:  "info",
+		constants.BPF_LOG_DEBUG: "debug",
+	}
+
+	loggerLevel, exists := logLevelMap[int(logLevel)]
+	if !exists {
+		return nil, fmt.Errorf("unexpected invalid log level: %d", logLevel)
+	}
+
+	return &LoggerInfo{
+		Name:  bpfLoggerName,
+		Level: loggerLevel,
+	}, nil
+}
+
+func (s *Server) setBpfLogLevel(w http.ResponseWriter, levelStr string) {
+	level, err := strconv.Atoi(levelStr)
+	if err != nil {
+		logLevelMap := map[string]int{
+			"error": constants.BPF_LOG_ERR,
+			"warn":  constants.BPF_LOG_WARN,
+			"info":  constants.BPF_LOG_INFO,
+			"debug": constants.BPF_LOG_DEBUG,
+		}
+		var exists bool
+		if level, exists = logLevelMap[levelStr]; !exists {
+			http.Error(w, "Invalid log level", http.StatusBadRequest)
+			return
+		}
+	}
+	if level < constants.BPF_LOG_ERR || level > constants.BPF_LOG_DEBUG {
+		http.Error(w, "Invalid log level", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.loader.UpdateBpfLogLevel(uint32(level)); err != nil {
+		http.Error(w, fmt.Sprintf("update bpf log level error: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	fmt.Fprintf(w, "set BPF Log Level: %d\n", level)
+}
+
+func (s *Server) StartServer() {
+	go func() {
+		err := s.server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Errorf("Failed to start status server: %v", err)
+		}
+	}()
+}
+
+func (s *Server) StopServer() error {
+	return s.server.Close()
+}
+
+func printWorkloadDump(w http.ResponseWriter, wd WorkloadDump) {
+	sort.Slice(wd.Workloads, func(i, j int) bool {
+		return wd.Workloads[i].Name < wd.Workloads[j].Name
+	})
+	sort.Slice(wd.Services, func(i, j int) bool {
+		return wd.Services[i].Name < wd.Services[j].Name
+	})
+	sort.Slice(wd.Policies, func(i, j int) bool {
+		return wd.Policies[i].Name < wd.Policies[j].Name
+	})
+
+	data, err := json.MarshalIndent(wd, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal WorkloadDump: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}


### PR DESCRIPTION
# What type of PR is this?

/kind feature

---

# What this PR does / why we need it

This PR expands the:

```text
/debug/ready
```

endpoint to provide granular health visibility for:
- eBPF programs
- eBPF maps
- XDS stream stability

These enhancements improve operational observability and enable:

```text
Visual indicators of mesh status
```

in the Headlamp plugin.

This allows users to verify:
- Whether BPF programs are correctly attached
- Whether required BPF maps are healthy
- Whether the XDS control plane connection is stable

Previously, the readiness endpoint only exposed coarse readiness state, making it difficult to diagnose partial failures or unstable control plane connectivity.

---

# Key changes

## Granular BPF status reporting

Expanded `BpfLoader` readiness reporting to include:
- Individual eBPF program attachment status
- eBPF map readiness information
- Detailed component-level health visibility

This improves low-level dataplane observability.

---

## XDS stream stability tracking

Added thread-safe XDS connection stability tracking in:

```go
XdsClient
```

including:
- Reconnect counts
- Last successful connect time
- Stream stability metadata

This provides better visibility into:
- Control plane health
- ADS stream reliability
- Reconnection behavior

---

## Expanded readiness response

Enhanced the JSON payload returned by:

```text
/debug/ready
```

to expose detailed component-level readiness information for:
- BPF programs
- Maps
- XDS connectivity
- Controller readiness

This makes the endpoint more useful for:
- Headlamp UI integration
- Monitoring systems
- Operational debugging

---

## Controller readiness integration

Integrated readiness checks into:
- `AdsController`
- `WorkloadController`

to provide centralized readiness reporting across core mesh components.

---

# Which issue(s) this PR fixes

Fixes #

```text
(Please add the issue number here if applicable)
```

---

# Special notes for your reviewer

## Thread safety

Introduced:

```go
sync.RWMutex
```

in:
- `XdsClient`
- Controllers

to ensure safe concurrent access during readiness and status reporting.

---

## Test updates

Updated:

```text
pkg/status/ready_test.go
```

to validate the new granular readiness response format.

---

## Formatting

Applied:

```bash
go fmt
```

to all modified files.

---

# Why this matters

These changes improve:
- Mesh observability
- Readiness diagnostics
- Control plane visibility
- Headlamp integration capabilities

Users can now identify:
- Missing BPF attachments
- Map initialization issues
- Unstable XDS streams
- Partial readiness failures

without relying on logs or deep internal debugging.

---

# Does this PR introduce a user-facing change?

```release-note
Expanded the /debug/ready endpoint to include granular status for eBPF programs, maps, and XDS stream stability for better mesh observability.
```