### PR TITLE
fix(ui): wrap markdown tables in responsive container for mobile

### DIFF
--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -1,0 +1,39 @@
+import React from "react";
+import Head from "@docusaurus/Head";
+import MDXCode from "@theme/MDXComponents/Code";
+import MDXA from "@theme/MDXComponents/A";
+import MDXPre from "@theme/MDXComponents/Pre";
+import MDXDetails from "@theme/MDXComponents/Details";
+import MDXHeading from "@theme/MDXComponents/Heading";
+import MDXUl from "@theme/MDXComponents/Ul";
+import MDXLi from "@theme/MDXComponents/Li";
+import MDXImg from "@theme/MDXComponents/Img";
+import Admonition from "@theme/Admonition";
+import Mermaid from "@theme/Mermaid";
+
+const MDXComponents = {
+  Head,
+  details: MDXDetails,
+  Details: MDXDetails,
+  code: MDXCode,
+  a: MDXA,
+  pre: MDXPre,
+  ul: MDXUl,
+  li: MDXLi,
+  img: MDXImg,
+  h1: (props) => <MDXHeading as="h1" {...props} />,
+  h2: (props) => <MDXHeading as="h2" {...props} />,
+  h3: (props) => <MDXHeading as="h3" {...props} />,
+  h4: (props) => <MDXHeading as="h4" {...props} />,
+  h5: (props) => <MDXHeading as="h5" {...props} />,
+  h6: (props) => <MDXHeading as="h6" {...props} />,
+  admonition: Admonition,
+  mermaid: Mermaid,
+  table: (props) => (
+    <div style={{ overflowX: "auto" }} tabIndex={0}>
+      <table {...props} />
+    </div>
+  ),
+};
+
+export default MDXComponents;


### PR DESCRIPTION
# [UI/UX] Audit and Fix Mobile Responsiveness for Markdown Tables

## Description
Currently, large Markdown tables in the documentation can exceed the viewport width on mobile devices, breaking the page layout or making the content difficult to read. 

This PR fixes the issue by customizing the Docusaurus `MDXComponents` to automatically wrap all Markdown documentation tables in a responsive container `<div>` styled with `overflow-x: auto`. This allows users to smoothly scroll wide tables horizontally on smaller screens while preserving the overall page width and layout integrity.

## Changes
* **`src/theme/MDXComponents/index.js`**: Swizzled the base MDX components map and added a custom `table` component wrapper with `overflowX: "auto"`.

## Verification
* Verified that Markdown tables render correctly and can be scrolled horizontally when the table width exceeds the container width on mobile viewports.
* Confirmed that no unrelated changes or files were introduced and Prettier formatting adheres strictly to project standards.

### Before

https://github.com/user-attachments/assets/7ba631bb-07b2-441a-9992-c0828204374a

### After

https://github.com/user-attachments/assets/d5fbd26d-e9e6-406e-a168-1bd97b16dadf


