### PR TITLE
refactor: replace legacy programmatic routing with semantic Link components

### DIFF
--- a/src/components/Blogs/index.js
+++ b/src/components/Blogs/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import SectionContainer from "../sectionContainer";
-import { useHistory } from "@docusaurus/router";
+import Link from "@docusaurus/Link";
 import Translate from "@docusaurus/Translate";
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import "./styles.scss";
@@ -10,11 +10,8 @@ export default function Blogs() {
 
     const { i18n: { currentLocale } } = useDocusaurusContext();
 
-    const {
-        blogGlobalData: { blogPosts },
-    } = usePluginData("blog-global-dataPlugin");
-
-    const history = useHistory();
+    const pluginData = usePluginData("blog-global-dataPlugin");
+    const blogPosts = pluginData?.blogGlobalData?.blogPosts || [];
 
     return (
         <SectionContainer className="blogPostContainer">
@@ -23,19 +20,17 @@ export default function Blogs() {
                     <h1>
                         <Translate>Recent News</Translate>
                     </h1>
-                    <a onClick={() => history.push("blog")}>
+                    <Link to="/blog">
                         <Translate>View All</Translate>
-                    </a>
+                    </Link>
                 </div>
                 <div className="right">
-                    {blogPosts.slice(0, 3).map((item, index) => (
-                        <div key={index} className="viewBlogContainer">
-                            <h3
-                                onClick={() =>
-                                    history.push(item.metadata.permalink)
-                                }
-                            >
-                                {item.metadata.title}
+                    {blogPosts.slice(0, 3).map((item) => (
+                        <div key={item.metadata.permalink} className="viewBlogContainer">
+                            <h3>
+                                <Link to={item.metadata.permalink}>
+                                    {item.metadata.title}
+                                </Link>
                             </h3>
                             {item.metadata?.frontMatter?.summary && (
                                 <p>{item.metadata?.frontMatter.summary}</p>
@@ -43,9 +38,9 @@ export default function Blogs() {
                             <div className="info">
                                 <div className="author">
                                     {(item.metadata?.authors || []).map(
-                                        (item) => (
-                                            <a href={item.url} target="_blank">
-                                                {item.name}
+                                        (author) => (
+                                            <a key={author.url || author.name} href={author.url} target="_blank" rel="noopener noreferrer">
+                                                {author.name}
                                             </a>
                                         )
                                     )}
@@ -68,3 +63,4 @@ export default function Blogs() {
         </SectionContainer>
     );
 }
+

--- a/src/components/slider/index.js
+++ b/src/components/slider/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import clsx from "clsx";
 import Slider from "react-slick";
 import Translate from "@docusaurus/Translate";
-import { useHistory } from "@docusaurus/router";
+import Link from "@docusaurus/Link";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import "./index.scss";
@@ -47,8 +47,6 @@ const SlideItem = (props) => {
     opacity = 0.5,
   } = props;
 
-  const history = useHistory();
-
   return (
     <div
       className={clsx("slick-item", align)}
@@ -67,12 +65,16 @@ const SlideItem = (props) => {
             width={160}
             height={30}
             title="GitHub Stars"
+            loading="lazy"
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           />
         </span>
       )}
       {button && (
         <div className={clsx("button")}>
-          <a onClick={() => history.push(button.url)}>{button.text}</a>
+          <Link to={button.url} className="slider-btn">
+            {button.text}
+          </Link>
         </div>
       )}
     </div>
@@ -91,10 +93,11 @@ export const HomeSlider = () => {
   return (
     <div className={"slider-container"}>
       <Slider {...settings}>
-        {sliderItems.map((i, index) => (
-          <SlideItem key={index} {...i} />
+        {sliderItems.map((item) => (
+          <SlideItem key={item.backgroundImage} {...item} />
         ))}
       </Slider>
     </div>
   );
 };
+


### PR DESCRIPTION
# Description
This PR refactors the website's programmatic routing to use standard semantic `<Link>` components from `@docusaurus/Link` instead of `useHistory` or legacy `<a>` tags with custom `onClick` click-handlers. Aligned with [Docusaurus Core Link Best Practices](https://docusaurus.io/docs/docusaurus-core#link) to leverage build-time broken link detection and smart client-side prefetching instead of fragile programmatic handlers

## The Problems Solved:
1. **Accessibility (a11y) Violations**: Custom `<a>` anchors used as buttons (e.g. "View All" buttons) lacked `href` attributes. These links were not focusable via keyboard (`Tab` navigation) and invisible to screen readers. 
2. **SEO & Search Indexability**: Crawlers like Googlebot only follow links containing real `href` attributes. The click handlers on the homepage blog title cards and navigation links were invisible to SEO indexing.
3. **Robust Version-Compatibility**: Programmatic routing hooks are prone to version mismatch between React Router V5/V6 during Docusaurus updates (e.g. `useHistory` deprecation). Moving to declarative semantic `<Link>` wraps completely avoids runtime hook dependencies.

## Changes:
- **`src/components/slider/index.js`**:
  - Replaced custom `<a onClick={() => history.push(...)}>` button wrap with a proper `<Link to={...}>` component.
  - Added secure `sandbox` and deferred `loading="lazy"` attributes to the GitHub Star button Iframe to eliminate initial render blockage.
  - Resolved `key={index}` anti-pattern to stable strings.
- **`src/components/Blogs/index.js`**:
  - Converted the "View All" legacy click-handler to a standard accessible `<Link to="/blog">`.
  - Refactored `<h3>` heading blog card elements so that the title string itself is safely wrapped inside a `<Link>` tag (restores native browser clickable behavior).
  - Added strict safe guards against potential missing/unresolved blog plugin data arrays to avoid runtime build breaks.

<img width="645" height="93" alt="image" src="https://github.com/user-attachments/assets/016927d2-eec3-4980-a58b-9c29d48a808f" />
