### PR TITLE
chore(netlify): fix canonical redirect to point to custom domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,12 @@ functions = "functions/"
 
 # Redirects for routing
 [[redirects]]
+  from = "https://kmesh-net.netlify.app/*"
+  to = "https://kmesh.net/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/latestversion"
   to = "/.netlify/functions/latestversion"
   status = 200
@@ -20,8 +26,3 @@ functions = "functions/"
   status = 301
   force = true # Ensure redirection
 
-[[redirects]]
-  from = "https://kmesh.net"
-  to = "https://kmesh-net.netlify.app"
-  status = 200
-  force = true


### PR DESCRIPTION
# Description
This PR resolves a backwards-redirect rule inside `netlify.toml` where our official premium custom domain (`kmesh.net`) was mapped to redirect/proxy to our Netlify staging subdomain (`kmesh-net.netlify.app`).

## The Problem:
1. **Backward Redirection**: Requests coming to the main official domain `https://kmesh.net` were routed internally via a `200` rewrite status to `https://kmesh-net.netlify.app`. 
2. **SEO Duplicate Content Penalty**: When a website serves identical contents across both its staging subdomain (`*.netlify.app`) and the official custom domain without a proper `301` canonical link consolidated mapping, Google and Bing indexers flag both domains for duplicate content. This splits our Domain Authority and organically de-ranks Kmesh in organic search results.

## The Solution:
We reversed the redirection logic to follow the recommended industry standard for Netlify-deployed custom domains:
- **Rule reversed**: Standard redirection is now set from the Netlify staging subdomain `https://kmesh-net.netlify.app/*` to the canonical domain `https://kmesh.net/:splat`.
- **Status code upgraded to `301`**: Swapped `200` (rewrite) to `301` (Permanent Redirect). This explicitly instructs search engine indexers that the staging subdomain has permanently shifted authority to the custom domain, consolidating all PageRank value.
- **Wildcard `:splat` support**: Ensures any sub-route visited on the staging app (e.g. `/docs/welcome`) cleanly redirects to the corresponding sub-route on the official domain, preventing any potential `404` errors.

<img width="696" height="290" alt="image" src="https://github.com/user-attachments/assets/557a9c29-572a-4f6b-ae1b-fbf80a2f1d19" />
