### PR TITLE
fix: replace hardcoded GA tracking ID with environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Google Analytics Tracking ID
+# For local development, copy this file to `.env` and set your real tracking ID.
+# For GitHub Actions, set `GA_TRACKING_ID` in repository variables (not secrets).
+# Reference: Settings > Secrets and variables > Actions > Variables
+# If deploying on Netlify, configure `GA_TRACKING_ID` in Netlify environment variables separately.
+GA_TRACKING_ID=G-XXXXXXXXXX

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build Docusaurus
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.14.0'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Docusaurus
+        run: yarn build
+        env:
+          GA_TRACKING_ID: ${{ vars.GA_TRACKING_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,10 +43,12 @@ const config = {
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },
-        gtag: {
-          trackingID: "G-854W8PEZ1Z",
-          anonymizeIP: true,
-        },
+        ...(process.env.GA_TRACKING_ID && {
+          gtag: {
+            trackingID: process.env.GA_TRACKING_ID,
+            anonymizeIP: true,
+          },
+        }),
         blog: {
           showReadingTime: true,
           feedOptions: {


### PR DESCRIPTION
## Summary
Fixes #252

Replaces the hardcoded Google Analytics tracking ID in `docusaurus.config.js` with an environment variable (`GA_TRACKING_ID`), following maintainer guidance from @hzxuzhonghu to use `vars.GA_TRACKING_ID` as a [repository configuration variable](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#using-the-vars-context-to-access-configuration-variable-values).

## Why not `secrets`?

The maintainer [explicitly created](https://github.com/kmesh-net/website/issues/252#issuecomment-2459053628) a repository **variable** (not secret) named `GA_TRACKING_ID`. This PR uses `${{ vars.GA_TRACKING_ID }}` accordingly — GA tracking IDs are not sensitive and don't need to be encrypted.

## What went wrong with PR #283

[PR #283](https://github.com/kmesh-net/website/pull/283) attempted to fix this issue but **fails the Netlify build CI check** because it uses:

```js
trackingID: process.env.GA_TRACKING_ID || "",
```

Docusaurus's `@docusaurus/plugin-google-gtag` validates that `trackingID` must be a non-empty string matching the GA format. An empty string `""` fails Joi schema validation with:

```txt
"trackingID" does not match any of the allowed types
```

## This PR's approach — conditional spread

Instead of providing a fallback empty string, this PR conditionally includes the entire `gtag` block only when the environment variable is set:

```js
...(process.env.GA_TRACKING_ID && {
  gtag: {
    trackingID: process.env.GA_TRACKING_ID,
    anonymizeIP: true,
  },
}),
```

✅ `GA_TRACKING_ID` is set → `gtag` config is included → analytics works  
✅ `GA_TRACKING_ID` is NOT set → `gtag` config is omitted entirely → build succeeds with no analytics (Netlify, local dev, forks)

## Changes

| File | Change |
|---|---|
| `docusaurus.config.js` | Replace hardcoded tracking ID with conditional `process.env.GA_TRACKING_ID` |
| `.github/workflows/build.yml` | New — CI build workflow passing `vars.GA_TRACKING_ID` |
| `.env.example` | New — Template for local development |
| `.gitignore` | Add `.env` entry |

## Build verification

Tested locally with `npm run build` — both `en` and `zh` locales build successfully without `GA_TRACKING_ID` set.
<img width="828" height="443" alt="image" src="https://github.com/user-attachments/assets/bdfd93b8-d59c-4b56-a7da-b933eb8dff7f" />


## Checklist

- [x] Hardcoded tracking ID removed from source code
- [x] Uses `vars.GA_TRACKING_ID` (not `secrets`) per maintainer guidance
- [x] Build passes without `GA_TRACKING_ID` set (graceful fallback)
- [x] Build passes with `GA_TRACKING_ID` set (analytics works)
- [x] `.env` added to `.gitignore`
