### PR TITLE
feat: add devcontainer for documentation development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kmesh Website Development",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+
+  // Install dependencies using yarn to match the project's lockfile
+  "postCreateCommand": "yarn install --frozen-lockfile",
+
+  // Forward Docusaurus dev server port
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Docusaurus Dev Server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+
+  // VS Code extensions and settings for documentation development
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "DavidAnson.vscode-markdownlint",
+        "streetsidesoftware.code-spell-checker",
+        "yzhang.markdown-all-in-one",
+        "dbaeumer.vscode-eslint"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ updates:
 
 ---
 
+## Development Environment
+
+You can start developing with zero manual setup using either **GitHub Codespaces** or **VS Code Dev Containers**.
+
+### Option 1: GitHub Codespaces (Recommended)
+
+Click the button below to open the project in a ready-to-code cloud environment:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kmesh-net/website)
+
+Once the Codespace is ready, start the dev server:
+
+```bash
+npm start
+# or
+yarn start
+```
+
+### Option 2: VS Code Dev Containers (Local)
+
+1. Install [Docker](https://www.docker.com/products/docker-desktop) and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code.
+2. Clone the repository and open it in VS Code.
+3. When prompted, click **"Reopen in Container"** — or run the command **Dev Containers: Reopen in Container** from the Command Palette.
+4. Dependencies are installed automatically. Start the dev server:
+
+   ```bash
+   npm start
+   # or
+   yarn start
+   ```
+
+Both options provide a pre-configured environment with Node.js 20 and recommended VS Code extensions for documentation development.
+
+---
+
 ## How to Install
 
 The Kmesh website is built using **Docusaurus** with React. Follow these steps to install and run it:


### PR DESCRIPTION
## Summary

Fixes #123

Currently, contributors need to manually install Node.js, dependencies, and handle platform-specific issues before they can start contributing to the Kmesh documentation. This PR adds a [Dev Container](https://containers.dev/) configuration that provides a pre-configured, ready-to-code environment — eliminating manual setup entirely.

## What this PR does

### 1. Adds `.devcontainer/devcontainer.json`

A devcontainer configuration that provides:

- **Base image**: `mcr.microsoft.com/devcontainers/javascript-node:20` — matches the project's Node.js 20 requirement and the Netlify production environment (`NODE_VERSION = 20.14.0` in `netlify.toml`)
- **Auto dependency install**: Runs `yarn install --frozen-lockfile` on container creation so contributors don't need to run it manually
- **Port forwarding**: Automatically forwards port `3000` (Docusaurus dev server) and opens the browser
- **VS Code extensions** pre-installed:
  - `markdownlint` — aligns with the project's [lint CI workflow](https://github.com/kmesh-net/website/blob/main/.github/workflows/lint.yml)
  - `code-spell-checker` — aligns with the project's [codespell CI workflow](https://github.com/kmesh-net/website/blob/main/.github/workflows/codespell.yml)
  - `markdown-all-in-one` — TOC generation, preview, and keyboard shortcuts for docs editing
  - `eslint` — JavaScript linting for configuration files

### 2. Updates `README.md`

Adds a **"Development Environment"** section with instructions for:

- **GitHub Codespaces** — one-click setup with an "Open in Codespaces" badge
- **VS Code Dev Containers** — local Docker-based setup with step-by-step guide

Both options follow the existing README convention of showing `npm` and `yarn` alternatives.

## How to test

### GitHub Codespaces
1. Go to **Code** → **Codespaces** → **Create codespace on `feat/add-devcontainer`**
2. Wait for the container to build and dependencies to install automatically
3. Run `npm start` or `yarn start`
4. Verify the Docusaurus dev server starts and is accessible at port 3000

### VS Code Dev Containers (Local)
1. Ensure Docker is running locally
2. Open the repo in VS Code → click **"Reopen in Container"**
3. Run `npm start` or `yarn start`
4. Verify the dev server starts at `http://localhost:3000`

## Files changed

| File | Change | Lines |
|---|---|---|
| `.devcontainer/devcontainer.json` | **New** | +31 |
| `README.md` | **Modified** | +35 |

**Total: 2 files, 66 additions**
