### PR TITLE
fix(css): improve mobile responsiveness for navbar search and header

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -168,3 +168,95 @@
     align-items: center;
   }
 }
+
+/* =====================================================
+   Mobile Navbar Search Responsiveness (fixes #304)
+   ===================================================== */
+
+/* 996px and below: constrain search so logo + hamburger always fit */
+@media (max-width: 996px) {
+  .navbar__search {
+    max-width: 160px;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  /* Hide the placeholder text — icon-only saves horizontal space */
+  .navbar__search input::placeholder,
+  .DocSearch-Button-Placeholder {
+    display: none;
+  }
+
+  /* Lock the brand (logo + title) so it never gets squeezed out */
+  .navbar__brand {
+    flex-shrink: 0;
+  }
+}
+
+/* Below 400px: allow search to expand fully when focused,
+   collapse to icon-only when idle.
+   NOTE: font-size kept ≥ 16px to prevent iOS Safari auto-zoom. */
+@media (max-width: 400px) {
+  .navbar__search {
+    max-width: 2.2rem;
+    transition: max-width 0.2s ease;
+  }
+
+  .navbar__search:focus-within {
+    max-width: 100%;
+  }
+
+  /* Reduce navbar horizontal padding on very small screens */
+  .navbar {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+}
+
+/* =====================================================
+   Lunr Search Results Modal — Mobile Improvements
+   ===================================================== */
+
+/* Truncate long category headings with ellipsis */
+.search-result-match__category,
+[class*="searchResultItem"] h3,
+[class*="lunr"] .category-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Clamp snippet text to 2 lines on mobile */
+@media (max-width: 996px) {
+  .search-result-match__summary,
+  [class*="searchResultItem"] p {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 0.85rem;
+  }
+
+  /* Tighten internal padding of result items */
+  [class*="searchResultItem"],
+  .search-result-match {
+    padding: 0.4rem 0.6rem;
+  }
+}
+
+/* At 400px and below: stretch results modal to full viewport width
+   Use left:0 + right:0 (not width:100vw) to avoid horizontal overflow
+   caused by scrollbar width on some browsers. */
+@media (max-width: 400px) {
+  [class*="searchResultsContainer"],
+  .lunr-search-results,
+  #lunr-search-results-container {
+    position: fixed;
+    left: 0;
+    right: 0;
+    max-height: 60vh;
+    overflow-y: auto;
+    border-radius: 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+}


### PR DESCRIPTION
## Summary

Re-submission of #310 and Solves #304 (auto-closed when fork was accidentally deleted).

On screens narrower than 996px the search input was expanding to its full intrinsic
width, squeezing the logo and hamburger toggle out of view. Category labels inside
the lunr-search results modal would also wrap awkwardly or get truncated on
sub-400px viewports.

## Changes in `src/css/custom.css`

- Constrain `.navbar__search` to `max-width: 160px` on mobile so the logo and
  hamburger always have room (`flex-shrink` + `min-width: 0`).
- Hide DocSearch placeholder text on mobile (icon-only saves space).
- Lock `.navbar__brand` with `flex-shrink: 0` to prevent logo clipping.
- Below 400px: collapse search to icon-only width (`2.2rem`) when idle,
  expand to full width on focus using `:focus-within`.
- **Font size is NOT set to 0** — this prevents the iOS Safari auto-zoom bug
  (addressed from previous review feedback).
- In the lunr-search results dropdown: apply `text-overflow: ellipsis` to
  category headings, clamp snippet text to 2 lines, tighten padding.
- At 400px and below: stretch the results modal using `left: 0` + `right: 0`
  (NOT `width: 100vw`) to avoid horizontal overflow from scrollbar width.
- Added `60vh` max-height with scroll so it never clips outside the viewport.

## Review Feedback Addressed (from #310)

| Issue | Fix |
|-------|-----|
| `font-size: 0` triggers iOS Safari zoom | Removed — font size never touched |
| `width: 100vw` causes horizontal overflow | Changed to `left: 0` + `right: 0` |
| Search unusable when collapsed | Added `:focus-within` to expand on tap |

Closes #304
