### PR TITLE
fix: add missing .logoImage CSS class in CNCFInfo component

### DIFF
--- a/src/components/CNCFInfo/styles.module.css
+++ b/src/components/CNCFInfo/styles.module.css
@@ -24,4 +24,9 @@
   .cncfLine2 {
     font-size: 1.8rem;
   }
-  
+
+  .logoImage {
+    width: 100%;
+    height: auto;
+    display: block;
+  }


### PR DESCRIPTION
Hey,

While going through the codebase I noticed that in the `CNCFInfo` component,
the `<img>` tag for the CNCF logo has `className={styles.logoImage}` applied
to it, but if you check `styles.module.css` — the `.logoImage` class is
simply not there.

So basically the styling was being referenced but never defined, meaning the
logo just renders at whatever default size the SVG falls back to. Not great.

Added the class with some straightforward responsive styles:

- `width: 100%` so it fills its container
- `max-width: 400px` to keep it from going too wide
- `height: auto` to maintain aspect ratio
- `display: block` + `margin: 0 auto` to center it properly

Tested locally, logo looks fine on the homepage in both light and dark mode.

Closes #326
